### PR TITLE
Publish on crates.io

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,3 +18,15 @@ jobs:
           bin: zip-password-finder
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  publish-crate:
+    name: "Publish on crates.io"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v3
+      - name: Publish
+        uses: actions-rs/cargo@v1
+        with:
+          command: publish
+          args: --token ${{ secrets.CARGO_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -17,6 +17,14 @@ The available charsets for generation are:
 - medium: easy + digits
 - hard: medium + punctuations and extras
 
+## Installation
+
+### [crates.io](https://crates.io/crates/zip-password-finder)
+
+```
+cargo install zip-password-finder
+```
+
 ## Usage
 
 ```


### PR DESCRIPTION
closes #40

Don't forget the add your cargo token as `CARGO_TOKEN` to the repository secrets before creating a release!
