### PR TITLE
Add fileNumber arg

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -63,6 +63,15 @@ fn command() -> clap::Command {
                 .default_value("10")
                 .required(false),
         )
+        .arg(
+            Arg::new("fileNumber")
+                .value_parser(value_parser!(usize))
+                .help("file number in the zip archive")
+                .long("fileNumber")
+                .num_args(1)
+                .default_value("0")
+                .required(false),
+        )
 }
 
 pub struct Arguments {
@@ -71,6 +80,7 @@ pub struct Arguments {
     pub charset_choice: CharsetChoice,
     pub min_password_len: usize,
     pub max_password_len: usize,
+    pub file_number: usize,
     pub password_dictionary: Option<String>,
 }
 
@@ -123,12 +133,15 @@ pub fn get_args() -> Result<Arguments, FinderError> {
         });
     }
 
+    let file_number: &usize = matches.get_one("fileNumber").expect("impossible");
+
     Ok(Arguments {
         input_file: input_file.clone(),
         workers: workers.cloned(),
         charset_choice,
         min_password_len: *min_password_len,
         max_password_len: *max_password_len,
+        file_number: *file_number,
         password_dictionary: password_dictionary.cloned(),
     })
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,6 +33,7 @@ fn main_result() -> Result<(), FinderError> {
         charset_choice,
         min_password_len,
         max_password_len,
+        file_number,
         password_dictionary,
     } = get_args()?;
 
@@ -52,7 +53,7 @@ fn main_result() -> Result<(), FinderError> {
     };
 
     let workers = workers.unwrap_or_else(num_cpus::get_physical);
-    let password = password_finder(&input_file, workers, strategy)?;
+    let password = password_finder(&input_file, workers, file_number, strategy)?;
     match password {
         Some(password) => println!("Password found: {password}"),
         None => println!("Password not found"),

--- a/src/password_finder.rs
+++ b/src/password_finder.rs
@@ -23,6 +23,7 @@ pub enum Strategy {
 pub fn password_finder(
     zip_path: &str,
     workers: usize,
+    file_number: usize,
     strategy: Strategy,
 ) -> Result<Option<String>, FinderError> {
     let file_path = Path::new(zip_path);
@@ -38,7 +39,7 @@ pub fn password_finder(
     progress_bar.set_draw_target(draw_target);
 
     // Fail early if the zip file is not valid
-    let aes_info = validate_zip(file_path)?;
+    let aes_info = validate_zip(file_path, file_number)?;
     match &aes_info {
         Some(aes_info) => progress_bar.println(format!(
             "Archive is encrypted with AES{} - expect a long wait time",
@@ -81,6 +82,7 @@ pub fn password_finder(
             i,
             workers,
             file_path,
+            file_number,
             aes_info.clone(),
             strategy.clone(),
             send_found_password.clone(),
@@ -127,7 +129,8 @@ mod tests {
             max_password_len,
         };
         let workers = num_cpus::get_physical();
-        password_finder(path, workers, strategy)
+        let file_number = 0;
+        password_finder(path, workers, file_number, strategy)
     }
 
     fn find_password_dictionary(path: &str) -> Result<Option<String>, FinderError> {
@@ -135,7 +138,8 @@ mod tests {
             "test-files/generated-passwords-lowercase.txt",
         ));
         let workers = num_cpus::get_physical();
-        password_finder(path, workers, strategy)
+        let file_number = 0;
+        password_finder(path, workers, file_number, strategy)
     }
 
     #[test]

--- a/src/password_worker.rs
+++ b/src/password_worker.rs
@@ -43,6 +43,7 @@ pub fn password_checker(
     index: usize,
     worker_count: usize,
     file_path: &Path,
+    file_number: usize,
     aes_info: Option<AesInfo>,
     strategy: Strategy,
     send_password_found: Sender<String>,
@@ -126,7 +127,7 @@ pub fn password_checker(
                     // This function sometimes accepts wrong password. This is because the ZIP spec only allows us to check for a 1/256 chance that the password is correct.
                     // There are many passwords out there that will also pass the validity checks we are able to perform.
                     // This is a weakness of the ZipCrypto algorithm, due to its fairly primitive approach to cryptography.
-                    let res = archive.by_index_decrypt(0, password_bytes);
+                    let res = archive.by_index_decrypt(file_number, password_bytes);
                     match res {
                         Ok(Err(_)) => (), // invalid password
                         Ok(Ok(mut zip)) => {

--- a/src/zip_utils.rs
+++ b/src/zip_utils.rs
@@ -26,11 +26,11 @@ impl AesInfo {
 }
 
 // validate that the zip requires a password
-pub fn validate_zip(file_path: &Path) -> Result<Option<AesInfo>, FinderError> {
+pub fn validate_zip(file_path: &Path, file_number: usize) -> Result<Option<AesInfo>, FinderError> {
     let file = File::open(file_path)?;
     let mut archive = zip::ZipArchive::new(file)?;
-    let aes_data = archive.get_aes_key_and_salt(0);
-    let zip_result = archive.by_index(0);
+    let aes_data = archive.get_aes_key_and_salt(file_number);
+    let zip_result = archive.by_index(file_number);
     match zip_result {
         Ok(_) => Err(FinderError::invalid_zip_error(
             "the archive is not encrypted".to_string(),


### PR DESCRIPTION
Sometimes the first file in a zip might not be encrypted. This pull request added a new argument to make finder work on such zips with `--fileNumber <n>`.