### PR TITLE
GPU acceleration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,15 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
+      # GPU unit tests call `wgpu::Instance::request_adapter` and panic if no
+      # adapter is found. Linux runners need a software Vulkan stack so wgpu
+      # can pick up llvmpipe; macOS has Metal and Windows has WARP DX12 by
+      # default, no install needed.
+      - name: Install software Vulkan (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y mesa-vulkan-drivers
       - name: Check code formatting
         run: cargo fmt --all -- --check
       - name: Build

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -689,7 +689,7 @@ dependencies = [
  "log",
  "presser",
  "thiserror",
- "windows 0.58.0",
+ "windows",
 ]
 
 [[package]]
@@ -1928,8 +1928,8 @@ dependencies = [
  "web-sys",
  "wgpu-naga-bridge",
  "wgpu-types",
- "windows 0.62.2",
- "windows-core 0.62.2",
+ "windows",
+ "windows-core",
 ]
 
 [[package]]
@@ -1989,23 +1989,14 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.58.0"
+version = "0.62.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
-dependencies = [
- "windows-core 0.58.0",
- "windows-targets",
-]
-
-[[package]]
-name = "windows"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+checksum = "9579d0e6970fd5250aa29aba5994052385ff55cf7b28a059e484bb79ea842e42"
 dependencies = [
  "windows-collections",
- "windows-core 0.62.2",
+ "windows-core",
  "windows-future",
+ "windows-link",
  "windows-numerics",
 ]
 
@@ -2015,20 +2006,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
- "windows-core 0.62.2",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
-dependencies = [
- "windows-implement 0.58.0",
- "windows-interface 0.58.0",
- "windows-result 0.2.0",
- "windows-strings 0.1.0",
- "windows-targets",
+ "windows-core",
 ]
 
 [[package]]
@@ -2037,11 +2015,11 @@ version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement 0.60.2",
- "windows-interface 0.59.3",
+ "windows-implement",
+ "windows-interface",
  "windows-link",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]
@@ -2050,20 +2028,9 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
 dependencies = [
- "windows-core 0.62.2",
+ "windows-core",
  "windows-link",
  "windows-threading",
-]
-
-[[package]]
-name = "windows-implement"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -2071,17 +2038,6 @@ name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2111,17 +2067,8 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
- "windows-core 0.62.2",
+ "windows-core",
  "windows-link",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
-dependencies = [
- "windows-targets",
 ]
 
 [[package]]
@@ -2131,16 +2078,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
-dependencies = [
- "windows-result 0.2.0",
- "windows-targets",
 ]
 
 [[package]]
@@ -2162,22 +2099,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-targets"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
-dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
-
-[[package]]
 name = "windows-threading"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2185,54 +2106,6 @@ checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
 dependencies = [
  "windows-link",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,6 +38,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -100,10 +115,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "ash"
+version = "0.38.0+1.3.281"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bb44936d800fea8f016d7f2311c6a4f97aebd5dc86f09906139ec848cf3a46f"
+dependencies = [
+ "libloading",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "bit-set"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34ddef2995421ab6a5c779542c81ee77c115206f4ad9d5a8e05f4ff49716a3dd"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
 
 [[package]]
 name = "bitflags"
@@ -144,6 +189,26 @@ name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "bzip2"
@@ -253,6 +318,17 @@ name = "cmov"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
+
+[[package]]
+name = "codespan-reporting"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af491d569909a7e4dee0ad7db7f5341fef5c614d5b8ec8cf765732aba3cff681"
+dependencies = [
+ "serde",
+ "termcolor",
+ "unicode-width",
+]
 
 [[package]]
 name = "colorchoice"
@@ -446,6 +522,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "dlib"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a"
+dependencies = [
+ "libloading",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -486,6 +580,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -523,6 +647,72 @@ dependencies = [
 ]
 
 [[package]]
+name = "gl_generator"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a95dfc23a2b4a9a2f5ab41d194f8bfda3cabec42af4e39f08c339eb2a0c124d"
+dependencies = [
+ "khronos_api",
+ "log",
+ "xml-rs",
+]
+
+[[package]]
+name = "glow"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29038e1c483364cc6bb3cf78feee1816002e127c331a1eec55a4d202b9e1adb5"
+dependencies = [
+ "js-sys",
+ "slotmap",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "glutin_wgl_sys"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c4ee00b289aba7a9e5306d57c2d05499b2e5dc427f84ac708bd2c090212cf3e"
+dependencies = [
+ "gl_generator",
+]
+
+[[package]]
+name = "gpu-allocator"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51255ea7cfaadb6c5f1528d43e92a82acb2b96c43365989a28b2d44ee38f8795"
+dependencies = [
+ "ash",
+ "hashbrown 0.16.1",
+ "log",
+ "presser",
+ "thiserror",
+ "windows 0.58.0",
+]
+
+[[package]]
+name = "gpu-descriptor"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b89c83349105e3732062a895becfc71a8f921bb71ecbbdd8ff99263e3b53a0ca"
+dependencies = [
+ "bitflags",
+ "gpu-descriptor-types",
+ "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "gpu-descriptor-types"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdf242682df893b86f33a73828fb09ca4b2d3bb6cc95249707fc684d27484b91"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -530,6 +720,7 @@ checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
  "cfg-if",
  "crunchy",
+ "num-traits",
  "zerocopy",
 ]
 
@@ -539,7 +730,18 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -559,6 +761,12 @@ name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hexf-parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
 
 [[package]]
 name = "hmac"
@@ -646,6 +854,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jni-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -661,9 +897,28 @@ version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "khronos-egl"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6aae1df220ece3c0ada96b8153459b67eebe9ae9212258bb0134ae60416fdf76"
+dependencies = [
+ "libc",
+ "libloading",
+ "pkg-config",
+]
+
+[[package]]
+name = "khronos_api"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 
 [[package]]
 name = "leb128fmt"
@@ -682,6 +937,37 @@ name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -715,6 +1001,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "naga"
+version = "29.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa2630921705b9b01dcdd0b6864b9562ca3c1951eecd0f0c4f5f04f61e412647"
+dependencies = [
+ "arrayvec",
+ "bit-set",
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "codespan-reporting",
+ "half",
+ "hashbrown 0.16.1",
+ "hexf-parse",
+ "indexmap",
+ "libm",
+ "log",
+ "num-traits",
+ "once_cell",
+ "rustc-hash",
+ "spirv",
+ "thiserror",
+ "unicode-ident",
+]
+
+[[package]]
+name = "ndk-sys"
+version = "0.6.0+11769913"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873"
+dependencies = [
+ "jni-sys 0.3.1",
+]
+
+[[package]]
 name = "nix"
 version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -739,6 +1060,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -761,10 +1083,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags",
+ "dispatch2",
+ "objc2",
+]
+
+[[package]]
 name = "objc2-encode"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-metal"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0125f776a10d00af4152d74616409f0d4a2053a6f57fa5b7d6aa2854ac04794"
+dependencies = [
+ "bitflags",
+ "block2",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-quartz-core"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "objc2-metal",
+]
 
 [[package]]
 name = "once_cell"
@@ -785,6 +1154,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
+name = "ordered-float"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "page_size"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -792,6 +1170,29 @@ checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
 ]
 
 [[package]]
@@ -805,16 +1206,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
+name = "pollster"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "powerfmt"
@@ -827,6 +1249,12 @@ name = "ppmd-rust"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efca4c95a19a79d1c98f791f10aebd5c1363b473244630bb7dbde1dc98455a24"
+
+[[package]]
+name = "presser"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf8e6a8aa66ce33f63993ffc4ea4271eb5b0530a9002db8455ea6050c77bfa"
 
 [[package]]
 name = "prettyplease"
@@ -848,6 +1276,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "profiling"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3eb8486b569e12e2c32ad3e204dbaba5e4b5b216e9367044f25f1dba42341773"
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -867,6 +1301,39 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "range-alloc"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca45419789ae5a7899559e9512e58ca889e41f04f1f2445e9f4b290ceccd1d08"
+
+[[package]]
+name = "raw-window-handle"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
+
+[[package]]
+name = "raw-window-metal"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40d213455a5f1dc59214213c7330e074ddf8114c9a42411eb890c767357ce135"
+dependencies = [
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "objc2-quartz-core",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
 
 [[package]]
 name = "regex"
@@ -898,6 +1365,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "renderdoc-sys"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -911,6 +1390,12 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
@@ -996,6 +1481,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "slotmap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdd58c3c93c3d278ca835519292445cb4b0d4dc59ccfdf7ceadaab3f8aeb4038"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "spirv"
+version = "0.4.0+sdk-1.4.341.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9571ea910ebd84c86af4b3ed27f9dbdc6ad06f17c5f96146b2b671e2976744f"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1010,6 +1531,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -1152,6 +1682,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1218,6 +1758,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "wayland-sys"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
+dependencies = [
+ "dlib",
+ "log",
+ "once_cell",
+ "pkg-config",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "web-time"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1225,6 +1787,173 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "wgpu"
+version = "29.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72c239a9a747bbd379590985bac952c2e53cb19873f7072b3370c6a6a8e06837"
+dependencies = [
+ "arrayvec",
+ "bitflags",
+ "bytemuck",
+ "cfg-if",
+ "cfg_aliases",
+ "document-features",
+ "hashbrown 0.16.1",
+ "js-sys",
+ "log",
+ "naga",
+ "parking_lot",
+ "portable-atomic",
+ "profiling",
+ "raw-window-handle",
+ "smallvec",
+ "static_assertions",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "wgpu-core",
+ "wgpu-hal",
+ "wgpu-types",
+]
+
+[[package]]
+name = "wgpu-core"
+version = "29.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e80ac6cf1895df6342f87d975162108f9d98772a0d74bc404ab7304ac29469e"
+dependencies = [
+ "arrayvec",
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "bytemuck",
+ "cfg_aliases",
+ "document-features",
+ "hashbrown 0.16.1",
+ "indexmap",
+ "log",
+ "naga",
+ "once_cell",
+ "parking_lot",
+ "portable-atomic",
+ "profiling",
+ "raw-window-handle",
+ "rustc-hash",
+ "smallvec",
+ "thiserror",
+ "wgpu-core-deps-apple",
+ "wgpu-core-deps-emscripten",
+ "wgpu-core-deps-windows-linux-android",
+ "wgpu-hal",
+ "wgpu-naga-bridge",
+ "wgpu-types",
+]
+
+[[package]]
+name = "wgpu-core-deps-apple"
+version = "29.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43acd053312501689cd92a01a9638d37f3e41a5fd9534875efa8917ee2d11ac0"
+dependencies = [
+ "wgpu-hal",
+]
+
+[[package]]
+name = "wgpu-core-deps-emscripten"
+version = "29.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef043bf135cc68b6f667c55ff4e345ce2b5924d75bad36a47921b0287ca4b24a"
+dependencies = [
+ "wgpu-hal",
+]
+
+[[package]]
+name = "wgpu-core-deps-windows-linux-android"
+version = "29.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "725d5c006a8c02967b6d93ef04f6537ec4593313e330cfe86d9d3f946eb90f28"
+dependencies = [
+ "wgpu-hal",
+]
+
+[[package]]
+name = "wgpu-hal"
+version = "29.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89a47aef47636562f3937285af4c44b4b5b404b46577471411cc5313a921da7e"
+dependencies = [
+ "android_system_properties",
+ "arrayvec",
+ "ash",
+ "bit-set",
+ "bitflags",
+ "block2",
+ "bytemuck",
+ "cfg-if",
+ "cfg_aliases",
+ "glow",
+ "glutin_wgl_sys",
+ "gpu-allocator",
+ "gpu-descriptor",
+ "hashbrown 0.16.1",
+ "js-sys",
+ "khronos-egl",
+ "libc",
+ "libloading",
+ "log",
+ "naga",
+ "ndk-sys",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "objc2-metal",
+ "objc2-quartz-core",
+ "once_cell",
+ "ordered-float",
+ "parking_lot",
+ "portable-atomic",
+ "portable-atomic-util",
+ "profiling",
+ "range-alloc",
+ "raw-window-handle",
+ "raw-window-metal",
+ "renderdoc-sys",
+ "smallvec",
+ "thiserror",
+ "wasm-bindgen",
+ "wayland-sys",
+ "web-sys",
+ "wgpu-naga-bridge",
+ "wgpu-types",
+ "windows 0.62.2",
+ "windows-core 0.62.2",
+]
+
+[[package]]
+name = "wgpu-naga-bridge"
+version = "29.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4684f4410da0cf95a4cb63bb5edaac022461dedb6adf0b64d0d9b5f6890d51"
+dependencies = [
+ "naga",
+ "wgpu-types",
+]
+
+[[package]]
+name = "wgpu-types"
+version = "29.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec2675540fb1a5cfa5ef122d3d5f390e2c75711a0b946410f2d6ac3a0f77d1f6"
+dependencies = [
+ "bitflags",
+ "bytemuck",
+ "js-sys",
+ "log",
+ "raw-window-handle",
+ "web-sys",
 ]
 
 [[package]]
@@ -1259,10 +1988,169 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
+dependencies = [
+ "windows-core 0.58.0",
+ "windows-targets",
+]
+
+[[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core 0.62.2",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core 0.62.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
+dependencies = [
+ "windows-implement 0.58.0",
+ "windows-interface 0.58.0",
+ "windows-result 0.2.0",
+ "windows-strings 0.1.0",
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
+ "windows-link",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link",
+ "windows-threading",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result 0.2.0",
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"
@@ -1272,6 +2160,79 @@ checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "wit-bindgen"
@@ -1368,6 +2329,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "xml-rs"
+version = "0.8.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
+
+[[package]]
 name = "zerocopy"
 version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1424,6 +2391,7 @@ dependencies = [
 name = "zip-password-finder"
 version = "0.11.1"
 dependencies = [
+ "bytemuck",
  "clap",
  "criterion",
  "ctrlc",
@@ -1433,8 +2401,10 @@ dependencies = [
  "indicatif",
  "num_cpus",
  "pbkdf2",
+ "pollster",
  "sha1",
  "thiserror",
+ "wgpu",
  "zip",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,6 +38,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -94,10 +109,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayvec"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
+
+[[package]]
+name = "ash"
+version = "0.38.0+1.3.281"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bb44936d800fea8f016d7f2311c6a4f97aebd5dc86f09906139ec848cf3a46f"
+dependencies = [
+ "libloading",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "bit-set"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34ddef2995421ab6a5c779542c81ee77c115206f4ad9d5a8e05f4ff49716a3dd"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
 
 [[package]]
 name = "bitflags"
@@ -138,6 +183,26 @@ name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "bytemuck"
+version = "1.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6aedf8ae72766347502cf3cb4f41cf5e9cc37d28bee90f1fdaaae15f9cf9424"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f65693059b6b9c588b9f62fed1cedbf0a8b805631457ea162d68f0de186f3de5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "bzip2"
@@ -256,6 +321,17 @@ name = "cmov"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
+name = "codespan-reporting"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af491d569909a7e4dee0ad7db7f5341fef5c614d5b8ec8cf765732aba3cff681"
+dependencies = [
+ "serde",
+ "termcolor",
+ "unicode-width",
+]
 
 [[package]]
 name = "colorchoice"
@@ -417,6 +493,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "dlib"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a"
+dependencies = [
+ "libloading",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
+]
+
+[[package]]
 name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -449,6 +543,18 @@ dependencies = [
  "miniz_oxide",
  "zlib-rs",
 ]
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "futures-core"
@@ -488,6 +594,72 @@ dependencies = [
 ]
 
 [[package]]
+name = "gl_generator"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a95dfc23a2b4a9a2f5ab41d194f8bfda3cabec42af4e39f08c339eb2a0c124d"
+dependencies = [
+ "khronos_api",
+ "log",
+ "xml-rs",
+]
+
+[[package]]
+name = "glow"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29038e1c483364cc6bb3cf78feee1816002e127c331a1eec55a4d202b9e1adb5"
+dependencies = [
+ "js-sys",
+ "slotmap",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "glutin_wgl_sys"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c4ee00b289aba7a9e5306d57c2d05499b2e5dc427f84ac708bd2c090212cf3e"
+dependencies = [
+ "gl_generator",
+]
+
+[[package]]
+name = "gpu-allocator"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51255ea7cfaadb6c5f1528d43e92a82acb2b96c43365989a28b2d44ee38f8795"
+dependencies = [
+ "ash",
+ "hashbrown 0.16.1",
+ "log",
+ "presser",
+ "thiserror",
+ "windows",
+]
+
+[[package]]
+name = "gpu-descriptor"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b89c83349105e3732062a895becfc71a8f921bb71ecbbdd8ff99263e3b53a0ca"
+dependencies = [
+ "bitflags",
+ "gpu-descriptor-types",
+ "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "gpu-descriptor-types"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdf242682df893b86f33a73828fb09ca4b2d3bb6cc95249707fc684d27484b91"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -495,7 +667,28 @@ checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
  "cfg-if",
  "crunchy",
+ "num-traits",
  "zerocopy",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -509,6 +702,12 @@ name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hexf-parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
 
 [[package]]
 name = "hmac"
@@ -541,7 +740,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -589,6 +788,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jni-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -610,6 +837,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "khronos-egl"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6aae1df220ece3c0ada96b8153459b67eebe9ae9212258bb0134ae60416fdf76"
+dependencies = [
+ "libc",
+ "libloading",
+ "pkg-config",
+]
+
+[[package]]
+name = "khronos_api"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
+
+[[package]]
 name = "libbz2-rs-sys"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -620,6 +864,37 @@ name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -653,6 +928,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "naga"
+version = "29.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2bf919621e7975acb27d881bae2fb993e0d45c8e0446e85e6272971e00dc8df"
+dependencies = [
+ "arrayvec",
+ "bit-set",
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "codespan-reporting",
+ "half",
+ "hashbrown 0.16.1",
+ "hexf-parse",
+ "indexmap",
+ "libm",
+ "log",
+ "num-traits",
+ "once_cell",
+ "rustc-hash",
+ "spirv",
+ "thiserror",
+ "unicode-ident",
+]
+
+[[package]]
+name = "ndk-sys"
+version = "0.6.0+11769913"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873"
+dependencies = [
+ "jni-sys 0.3.1",
+]
+
+[[package]]
 name = "nix"
 version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -677,6 +987,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -699,10 +1010,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags",
+ "dispatch2",
+ "objc2",
+]
+
+[[package]]
 name = "objc2-encode"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-metal"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0125f776a10d00af4152d74616409f0d4a2053a6f57fa5b7d6aa2854ac04794"
+dependencies = [
+ "bitflags",
+ "block2",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-quartz-core"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "objc2-metal",
+]
 
 [[package]]
 name = "once_cell"
@@ -723,6 +1081,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
+name = "ordered-float"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "page_size"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -730,6 +1097,29 @@ checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
 ]
 
 [[package]]
@@ -755,10 +1145,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
+name = "pollster"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
+
+[[package]]
 name = "portable-atomic"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "powerfmt"
@@ -773,6 +1178,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efca4c95a19a79d1c98f791f10aebd5c1363b473244630bb7dbde1dc98455a24"
 
 [[package]]
+name = "presser"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf8e6a8aa66ce33f63993ffc4ea4271eb5b0530a9002db8455ea6050c77bfa"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -780,6 +1191,12 @@ checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "profiling"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d595e54a326bc53c1c197b32d295e14b169e3cfeaa8dc82b529f947fba6bcf5"
 
 [[package]]
 name = "quote"
@@ -795,6 +1212,39 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "range-alloc"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca45419789ae5a7899559e9512e58ca889e41f04f1f2445e9f4b290ceccd1d08"
+
+[[package]]
+name = "raw-window-handle"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
+
+[[package]]
+name = "raw-window-metal"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40d213455a5f1dc59214213c7330e074ddf8114c9a42411eb890c767357ce135"
+dependencies = [
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "objc2-quartz-core",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
 
 [[package]]
 name = "regex"
@@ -826,6 +1276,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
+name = "renderdoc-sys"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
 name = "rustversion"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -839,6 +1301,12 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
@@ -942,6 +1410,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
+name = "slotmap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdd58c3c93c3d278ca835519292445cb4b0d4dc59ccfdf7ceadaab3f8aeb4038"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
+name = "smallvec"
+version = "1.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+
+[[package]]
+name = "spirv"
+version = "0.4.0+sdk-1.4.341.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9571ea910ebd84c86af4b3ed27f9dbdc6ad06f17c5f96146b2b671e2976744f"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -956,6 +1454,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -1045,6 +1552,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
 name = "walkdir"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1065,6 +1578,16 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1100,6 +1623,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "wayland-sys"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
+dependencies = [
+ "dlib",
+ "log",
+ "once_cell",
+ "pkg-config",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "web-time"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1107,6 +1652,174 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "wgpu"
+version = "29.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76e8840e1ba2881d4cbb18d2147627a56af426ff064c0401eb0c8410c6325d07"
+dependencies = [
+ "arrayvec",
+ "bitflags",
+ "bytemuck",
+ "cfg-if",
+ "cfg_aliases",
+ "document-features",
+ "hashbrown 0.16.1",
+ "js-sys",
+ "log",
+ "naga",
+ "parking_lot",
+ "portable-atomic",
+ "profiling",
+ "raw-window-handle",
+ "smallvec",
+ "static_assertions",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "wgpu-core",
+ "wgpu-hal",
+ "wgpu-types",
+]
+
+[[package]]
+name = "wgpu-core"
+version = "29.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f519832254e56965a9940c4af57dcb75f702b6f6fa4a0b172f685395843a4d7"
+dependencies = [
+ "arrayvec",
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "bytemuck",
+ "cfg_aliases",
+ "document-features",
+ "hashbrown 0.16.1",
+ "indexmap",
+ "log",
+ "naga",
+ "once_cell",
+ "parking_lot",
+ "portable-atomic",
+ "profiling",
+ "raw-window-handle",
+ "rustc-hash",
+ "smallvec",
+ "thiserror",
+ "wgpu-core-deps-apple",
+ "wgpu-core-deps-emscripten",
+ "wgpu-core-deps-windows-linux-android",
+ "wgpu-hal",
+ "wgpu-naga-bridge",
+ "wgpu-types",
+]
+
+[[package]]
+name = "wgpu-core-deps-apple"
+version = "29.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5e39e26c4c0e07589e67d18546cf79ff45383659fc72fca4dd293358a0347f3"
+dependencies = [
+ "wgpu-hal",
+]
+
+[[package]]
+name = "wgpu-core-deps-emscripten"
+version = "29.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01e09be551dc939498bdd5f6b2c66e55ab275dad25825267a08605a80fc9f0af"
+dependencies = [
+ "wgpu-hal",
+]
+
+[[package]]
+name = "wgpu-core-deps-windows-linux-android"
+version = "29.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e592c1bbef6ad047647ae6e666ebd8cee7a32bb4544d9700ec96cbf73230257"
+dependencies = [
+ "wgpu-hal",
+]
+
+[[package]]
+name = "wgpu-hal"
+version = "29.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97ace1c17727311c22a46e4e3faf56ea6de81af99dcc839bdfb54857b94d448d"
+dependencies = [
+ "android_system_properties",
+ "arrayvec",
+ "ash",
+ "bit-set",
+ "bitflags",
+ "block2",
+ "bytemuck",
+ "cfg-if",
+ "cfg_aliases",
+ "glow",
+ "glutin_wgl_sys",
+ "gpu-allocator",
+ "gpu-descriptor",
+ "hashbrown 0.16.1",
+ "js-sys",
+ "khronos-egl",
+ "libc",
+ "libloading",
+ "log",
+ "naga",
+ "ndk-sys",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "objc2-metal",
+ "objc2-quartz-core",
+ "once_cell",
+ "ordered-float",
+ "parking_lot",
+ "portable-atomic",
+ "portable-atomic-util",
+ "profiling",
+ "range-alloc",
+ "raw-window-handle",
+ "raw-window-metal",
+ "renderdoc-sys",
+ "smallvec",
+ "thiserror",
+ "wasm-bindgen",
+ "wayland-sys",
+ "web-sys",
+ "wgpu-naga-bridge",
+ "wgpu-types",
+ "windows",
+ "windows-core",
+ "windows-result",
+]
+
+[[package]]
+name = "wgpu-naga-bridge"
+version = "29.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95226013f547544b223281cd16a4fb549aa9dcb562adbda0faae4c73ffbbc161"
+dependencies = [
+ "naga",
+ "wgpu-types",
+]
+
+[[package]]
+name = "wgpu-types"
+version = "29.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84bf84cd9ca8ca45e2b223a3868f1adf9bfc0c66aeac212e76ee7e40fdadf8f5"
+dependencies = [
+ "bitflags",
+ "bytemuck",
+ "js-sys",
+ "log",
+ "raw-window-handle",
+ "web-sys",
 ]
 
 [[package]]
@@ -1141,10 +1854,105 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"
@@ -1154,6 +1962,21 @@ checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "xml-rs"
+version = "0.8.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
 
 [[package]]
 name = "zerocopy"
@@ -1212,6 +2035,7 @@ dependencies = [
 name = "zip-password-finder"
 version = "0.12.0"
 dependencies = [
+ "bytemuck",
  "clap",
  "criterion",
  "ctrlc",
@@ -1221,9 +2045,11 @@ dependencies = [
  "indicatif",
  "num_cpus",
  "pbkdf2",
+ "pollster",
  "sevenz-rust2",
  "sha1",
  "thiserror",
+ "wgpu",
  "zip",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,9 +131,9 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "bit-set"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ddef2995421ab6a5c779542c81ee77c115206f4ad9d5a8e05f4ff49716a3dd"
+checksum = "09ec2f926cc3060f09db9ebc5b52823d85268d24bb917e472c0c4bea35780a7d"
 dependencies = [
  "bit-vec",
 ]
@@ -546,12 +546,6 @@ dependencies = [
 
 [[package]]
 name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-
-[[package]]
-name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
@@ -640,26 +634,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gpu-descriptor"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b89c83349105e3732062a895becfc71a8f921bb71ecbbdd8ff99263e3b53a0ca"
-dependencies = [
- "bitflags",
- "gpu-descriptor-types",
- "hashbrown 0.15.5",
-]
-
-[[package]]
-name = "gpu-descriptor-types"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdf242682df893b86f33a73828fb09ca4b2d3bb6cc95249707fc684d27484b91"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -673,22 +647,13 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "foldhash 0.1.5",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash 0.2.0",
+ "foldhash",
 ]
 
 [[package]]
@@ -696,18 +661,15 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "foldhash",
+]
 
 [[package]]
 name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
-
-[[package]]
-name = "hexf-parse"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
 
 [[package]]
 name = "hmac"
@@ -929,9 +891,9 @@ dependencies = [
 
 [[package]]
 name = "naga"
-version = "29.0.4"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2bf919621e7975acb27d881bae2fb993e0d45c8e0446e85e6272971e00dc8df"
+checksum = "23bf0a141a9ab6f07dbb492db53245e464bc9db42f407772d9ae03d83a2c1033"
 dependencies = [
  "arrayvec",
  "bit-set",
@@ -940,17 +902,29 @@ dependencies = [
  "cfg_aliases",
  "codespan-reporting",
  "half",
- "hashbrown 0.16.1",
- "hexf-parse",
+ "hashbrown 0.17.1",
  "indexmap",
  "libm",
  "log",
+ "naga-types",
  "num-traits",
  "once_cell",
  "rustc-hash",
  "spirv",
  "thiserror",
  "unicode-ident",
+]
+
+[[package]]
+name = "naga-types"
+version = "30.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "658200ddc25c6c7b860747516d132d1b284c0fafb7a380233acee9a72fb30e11"
+dependencies = [
+ "hashbrown 0.17.1",
+ "indexmap",
+ "rustc-hash",
+ "thiserror",
 ]
 
 [[package]]
@@ -1021,6 +995,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-graphics"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
+dependencies = [
+ "dispatch2",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-io-surface",
+]
+
+[[package]]
 name = "objc2-encode"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1031,6 +1017,17 @@ name = "objc2-foundation"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-surface"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
 dependencies = [
  "bitflags",
  "objc2",
@@ -1058,6 +1055,7 @@ dependencies = [
  "bitflags",
  "objc2",
  "objc2-core-foundation",
+ "objc2-core-graphics",
  "objc2-foundation",
  "objc2-metal",
 ]
@@ -1146,9 +1144,9 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "pollster"
-version = "0.4.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
+checksum = "bc6355899e1c9462875b6757c79f3caa011a1fdae12bbb1a2e72dd1f234f8336"
 
 [[package]]
 name = "portable-atomic"
@@ -1656,9 +1654,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu"
-version = "29.0.4"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76e8840e1ba2881d4cbb18d2147627a56af426ff064c0401eb0c8410c6325d07"
+checksum = "6d8f4bd44d92da5270f03409dba9f952dab24f128e05d6a554926101d1bf9114"
 dependencies = [
  "arrayvec",
  "bitflags",
@@ -1666,7 +1664,7 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "document-features",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "js-sys",
  "log",
  "naga",
@@ -1686,9 +1684,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "29.0.4"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f519832254e56965a9940c4af57dcb75f702b6f6fa4a0b172f685395843a4d7"
+checksum = "08763620e76fc980bca7bf84de82568614487a53172dd968d89187282eb87fa2"
 dependencies = [
  "arrayvec",
  "bit-set",
@@ -1697,10 +1695,11 @@ dependencies = [
  "bytemuck",
  "cfg_aliases",
  "document-features",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "indexmap",
  "log",
  "naga",
+ "naga-types",
  "once_cell",
  "parking_lot",
  "portable-atomic",
@@ -1719,36 +1718,36 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core-deps-apple"
-version = "29.0.4"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5e39e26c4c0e07589e67d18546cf79ff45383659fc72fca4dd293358a0347f3"
+checksum = "3283b6da70d7fc892de95840215aa36381b5d0cbc479e88ee2b173c7b992b225"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-core-deps-emscripten"
-version = "29.0.4"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01e09be551dc939498bdd5f6b2c66e55ab275dad25825267a08605a80fc9f0af"
+checksum = "85dcf2b2e5c2afb9eda64c570a87a4e570304bf39e52eddbaaf222d655b656ad"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-core-deps-windows-linux-android"
-version = "29.0.4"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e592c1bbef6ad047647ae6e666ebd8cee7a32bb4544d9700ec96cbf73230257"
+checksum = "f76bc9c1c186ff3d9054e0d224c93c8c1c79d6653907c5249a5c1ea1a2cb1e43"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-hal"
-version = "29.0.4"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97ace1c17727311c22a46e4e3faf56ea6de81af99dcc839bdfb54857b94d448d"
+checksum = "cf765132d8d5f50e192e7880464890c13f4e7457aafe8e5466e8174586e9f101"
 dependencies = [
  "android_system_properties",
  "arrayvec",
@@ -1762,17 +1761,18 @@ dependencies = [
  "glow",
  "glutin_wgl_sys",
  "gpu-allocator",
- "gpu-descriptor",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "js-sys",
  "khronos-egl",
  "libc",
  "libloading",
  "log",
  "naga",
+ "naga-types",
  "ndk-sys",
  "objc2",
  "objc2-core-foundation",
+ "objc2-core-graphics",
  "objc2-foundation",
  "objc2-metal",
  "objc2-quartz-core",
@@ -1787,6 +1787,7 @@ dependencies = [
  "raw-window-metal",
  "renderdoc-sys",
  "smallvec",
+ "static_assertions",
  "thiserror",
  "wasm-bindgen",
  "wayland-sys",
@@ -1800,9 +1801,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu-naga-bridge"
-version = "29.0.4"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95226013f547544b223281cd16a4fb549aa9dcb562adbda0faae4c73ffbbc161"
+checksum = "c9eaac644e5008925c78567d272b9d66ef83da55a53cc17fc7daade7bb6e66e5"
 dependencies = [
  "naga",
  "wgpu-types",
@@ -1810,15 +1811,17 @@ dependencies = [
 
 [[package]]
 name = "wgpu-types"
-version = "29.0.4"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84bf84cd9ca8ca45e2b223a3868f1adf9bfc0c66aeac212e76ee7e40fdadf8f5"
+checksum = "1a9c93c2b35edde326df60ffdee4c0f5864eac3011d6768b70d43f028ad93565"
 dependencies = [
  "bitflags",
  "bytemuck",
  "js-sys",
  "log",
+ "naga-types",
  "raw-window-handle",
+ "static_assertions",
  "web-sys",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,9 @@ num_cpus = "1.17.0"
 humantime = "2.3.0"
 ctrlc = "3.5"
 either = "1.15.0"
+wgpu = "29.0.1"
+pollster = "0.4.0"
+bytemuck = "1.25.0"
 
 [profile.release]
 lto = "fat"
@@ -45,4 +48,12 @@ harness = false
 
 [[bench]]
 name = "password_reader"
+harness = false
+
+[[bench]]
+name = "pbkdf2"
+harness = false
+
+[[bench]]
+name = "pbkdf2_gpu"
 harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,9 @@ humantime = "2.3.0"
 ctrlc = "3.5"
 either = "1.16.0"
 sevenz-rust2 = { version = "0.21.3", features = ["aes256", "util"] } # aes256 for encrypted archives, util for the reader helpers; default codecs (lzma/lzma2/...) stay enabled
+wgpu = "29.0.1"
+pollster = "0.4.0"
+bytemuck = "1.25.0"
 
 [profile.release]
 lto = "fat"
@@ -46,4 +49,12 @@ harness = false
 
 [[bench]]
 name = "password_reader"
+harness = false
+
+[[bench]]
+name = "pbkdf2"
+harness = false
+
+[[bench]]
+name = "pbkdf2_gpu"
 harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,8 @@ humantime = "2.3.0"
 ctrlc = "3.5"
 either = "1.16.0"
 sevenz-rust2 = { version = "0.21.3", features = ["aes256", "util"] } # aes256 for encrypted archives, util for the reader helpers; default codecs (lzma/lzma2/...) stay enabled
-wgpu = "29.0.1"
-pollster = "0.4.0"
+wgpu = "30.0.0"
+pollster = "1.0.1"
 bytemuck = "1.25.0"
 
 [profile.release]

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ If this tool helped you recover an archive, consider [sponsoring the project on 
 
 - Supports both ZipCrypto and AES encryption
 - Multi-threaded, using all physical CPU cores by default
+- Optional GPU acceleration via `--gpu` for AES archives (see [GPU acceleration](#gpu-acceleration))
 - Three attack modes: brute force, dictionary, and mask attack
 - Graceful interruption with Ctrl-C, displaying the last password tested
 - Resume brute force from a specific password with `--startingPassword`
@@ -104,6 +105,56 @@ zip-password-finder -i archive.zip --mask '?u?l?l?l?l?s'
 zip-password-finder -i archive.zip -1 "aeiou" --mask '?1?1?d'
 ```
 
+## GPU acceleration
+
+For **AES-encrypted** archives, the `--gpu` flag offloads PBKDF2-HMAC-SHA1 derivation to the GPU. Works on any modern desktop GPU via the platform's native graphics API (Vulkan on Linux, Metal on macOS, DX12 on Windows). No extra system dependencies — the binary ships with the GPU backend included.
+
+```bash
+zip-password-finder -i archive.zip -c lud --maxPasswordLen 6 --gpu
+```
+
+What it does:
+- Picks the highest-performance adapter at startup, prints which one it found.
+- Batches candidates (16 384 per dispatch) and runs PBKDF2-HMAC-SHA1 in a compute shader.
+- Falls back automatically to the CPU path when the remaining search space is below ~16 k candidates (GPU dispatch latency would dominate).
+- Errors out cleanly if `--gpu` is requested against a ZipCrypto archive.
+
+Constraints:
+- AES only. ZipCrypto is not supported on the GPU path.
+- Passwords up to 64 bytes (HMAC long-key path is not implemented). WinZip-AES passwords are well under this in practice.
+
+To probe whether your machine has a usable GPU before running a real search:
+
+```bash
+zip-password-finder --gpu-smoke-test
+```
+
+This lists detected adapters and runs a trivial compute kernel to confirm the device is functional.
+
+Expected speedup depends heavily on your hardware. On a Radeon 890M iGPU (RDNA 3.5, 16 CUs) the GPU path runs roughly **2–7× faster than 12 CPU cores** for AES-128/256 brute force — the larger the search space, the bigger the win. Discrete GPUs should do considerably better. The `pbkdf2_gpu` benchmark prints throughput in passwords-per-second across batch sizes:
+
+```bash
+cargo bench --bench pbkdf2_gpu
+```
+
+### Troubleshooting
+
+If `--gpu` exits with `GPU error - no compatible GPU adapter found`, the binary couldn't reach a working Vulkan/Metal/DX12 driver. Common causes:
+
+- **Headless / SSH session without a graphics stack**: the loader has no devices to enumerate. Either run on a desktop session, or install a software adapter (e.g. `mesa-vulkan-drivers` on Debian/Ubuntu, which provides Mesa's `lavapipe`).
+- **WSL without GPU passthrough**: WSL2 supports CUDA but Vulkan support is patchy. Use the CPU path or set up GPU passthrough.
+- **Stripped Docker container**: install your distribution's Vulkan or Mesa packages in the image.
+
+To diagnose, run the smoke test:
+
+```bash
+zip-password-finder --gpu-smoke-test
+```
+
+It lists detected adapters and runs a trivial compute kernel. Zero adapters listed means the GPU backend isn't reachable from this binary.
+
+If `--gpu` errors with `--gpu requires an AES-encrypted archive`, the archive uses ZipCrypto (legacy ZIP encryption). The GPU path is AES-only — drop the flag and the CPU path will handle it.
+
 ## Installation
 
 ### Releases
@@ -149,6 +200,8 @@ Options:
   -2, --customCharset2 <customCharset2>          custom charset 2 for mask attack, referenced as ?2
   -3, --customCharset3 <customCharset3>          custom charset 3 for mask attack, referenced as ?3
   -4, --customCharset4 <customCharset4>          custom charset 4 for mask attack, referenced as ?4
+  -g, --gpu                                      use the GPU (Vulkan/Metal/DX12 via wgpu) — requires AES-encrypted archive
+      --gpu-smoke-test                           list GPU adapters and run a trivial compute kernel, then exit (does not require --inputFile)
   -h, --help                                     Print help
   -V, --version                                  Print version
 ```

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ If this tool helped you recover an archive, consider [sponsoring the project on 
 
 - Supports ZIP (ZipCrypto + AES) and 7z (AES-256) archives
 - Multi-threaded, using all physical CPU cores by default
+- Optional GPU acceleration via `--gpu` for AES archives (see [GPU acceleration](#gpu-acceleration))
 - Three attack modes: brute force, dictionary, and mask attack
 - Graceful interruption with Ctrl-C, displaying the last password tested
 - Resume brute force from a specific password with `--starting-password`
@@ -122,6 +123,56 @@ A few things to keep in mind, all stemming from 7z's design rather than this too
 - **AES-256 only**, which is what every recent 7z build produces.
 - Unlike ZIP, 7z has no cheap per-candidate verifier, so each password is fully decrypt-and-checked. The `--file-number` option is **rejected** for 7z (it selects an entry in a multi-file ZIP; for 7z any encrypted entry proves the password). Verification uses whichever entry is cheapest to decode — the smallest one for non-solid archives — to keep the check fast even when the archive holds a large file.
 
+## GPU acceleration
+
+For **AES-encrypted** archives, the `--gpu` flag offloads PBKDF2-HMAC-SHA1 derivation to the GPU. Works on any modern desktop GPU via the platform's native graphics API (Vulkan on Linux, Metal on macOS, DX12 on Windows). No extra system dependencies — the binary ships with the GPU backend included.
+
+```bash
+zip-password-finder archive.zip -c lud --max-password-len 6 --gpu
+```
+
+What it does:
+- Picks the highest-performance adapter at startup, prints which one it found.
+- Batches candidates (16 384 per dispatch) and runs PBKDF2-HMAC-SHA1 in a compute shader.
+- Falls back automatically to the CPU path when the remaining search space is below ~16 k candidates (GPU dispatch latency would dominate).
+- Errors out cleanly if `--gpu` is requested against a ZipCrypto archive.
+
+Constraints:
+- AES only. ZipCrypto is not supported on the GPU path.
+- Passwords up to 64 bytes (HMAC long-key path is not implemented). WinZip-AES passwords are well under this in practice.
+
+To probe whether your machine has a usable GPU before running a real search:
+
+```bash
+zip-password-finder --gpu-smoke-test
+```
+
+This lists detected adapters and runs a trivial compute kernel to confirm the device is functional.
+
+Expected speedup depends heavily on your hardware. On a Radeon 890M iGPU (RDNA 3.5, 16 CUs) the GPU path runs roughly **2–7× faster than 12 CPU cores** for AES-128/256 brute force — the larger the search space, the bigger the win. Discrete GPUs should do considerably better. The `pbkdf2_gpu` benchmark prints throughput in passwords-per-second across batch sizes:
+
+```bash
+cargo bench --bench pbkdf2_gpu
+```
+
+### Troubleshooting
+
+If `--gpu` exits with `GPU error - no compatible GPU adapter found`, the binary couldn't reach a working Vulkan/Metal/DX12 driver. Common causes:
+
+- **Headless / SSH session without a graphics stack**: the loader has no devices to enumerate. Either run on a desktop session, or install a software adapter (e.g. `mesa-vulkan-drivers` on Debian/Ubuntu, which provides Mesa's `lavapipe`).
+- **WSL without GPU passthrough**: WSL2 supports CUDA but Vulkan support is patchy. Use the CPU path or set up GPU passthrough.
+- **Stripped Docker container**: install your distribution's Vulkan or Mesa packages in the image.
+
+To diagnose, run the smoke test:
+
+```bash
+zip-password-finder --gpu-smoke-test
+```
+
+It lists detected adapters and runs a trivial compute kernel. Zero adapters listed means the GPU backend isn't reachable from this binary.
+
+If `--gpu` errors with `--gpu requires an AES-encrypted archive`, the archive uses ZipCrypto (legacy ZIP encryption). The GPU path is AES-only — drop the flag and the CPU path will handle it.
+
 ## Installation
 
 ### Releases
@@ -150,10 +201,10 @@ paru -S zip-password-finder
 ./zip-password-finder -h
 Find the password of protected ZIP files
 
-Usage: zip-password-finder [OPTIONS] <file>
+Usage: zip-password-finder [OPTIONS] [file]
 
 Arguments:
-  <file>  path to the zip or 7z input file
+  [file]  path to the zip or 7z input file
 
 Options:
   -w, --workers <count>               number of workers
@@ -161,7 +212,7 @@ Options:
   -c, --charset <preset>              charset preset(s) to combine for brute force [default: lud]
       --charset-file <file>           path to a charset file
       --min-password-len <len>        minimum password length [default: 1]
-      --max-password-len <len>        maximum password length [default: 6]
+      --max-password-len <len>        maximum password length to brute-force [default: 6]
       --file-number <index>           file number in the zip archive [default: 0]
   -s, --starting-password <password>  password to start from
   -m, --mask <pattern>                mask pattern for mask attack (e.g. '?l?l?l?d?d')
@@ -171,6 +222,9 @@ Options:
   -4, --custom-charset-4 <chars>      custom charset 4 for mask attack, referenced as ?4
   -q, --quiet                         suppress progress and status output (print only the result on stdout)
       --json                          print the result as a JSON object on stdout
+  -g, --gpu                           use the GPU (Vulkan/Metal/DX12 via wgpu) — requires AES-encrypted archive
+      --gpu-smoke-test                list GPU adapters and run a trivial compute kernel, then exit (does not require an input file)
+      --gpu-batch-size <size>         override the GPU batch size (passwords per dispatch). When omitted, a value is picked automatically from the GPU type. Only used with --gpu.
   -h, --help                          Print help (see more with '--help')
   -V, --version                       Print version
 ```

--- a/benches/pbkdf2.rs
+++ b/benches/pbkdf2.rs
@@ -1,0 +1,33 @@
+use criterion::{Criterion, Throughput, criterion_group, criterion_main};
+use hmac::Hmac;
+use sha1::Sha1;
+use std::hint::black_box;
+
+fn bench_pbkdf2(c: &mut Criterion) {
+    let salt = [0u8; 16];
+    let password = b"password123";
+
+    let mut group = c.benchmark_group("pbkdf2_hmac_sha1_1000");
+    group.throughput(Throughput::Elements(1));
+
+    // AES-128 — derived key 34 bytes (2 SHA-1 output blocks)
+    group.bench_function("aes128_one_password", |b| {
+        let mut out = [0u8; 34];
+        b.iter(|| {
+            pbkdf2::pbkdf2::<Hmac<Sha1>>(black_box(password), &salt, 1000, &mut out).unwrap();
+        });
+    });
+
+    // AES-256 — derived key 66 bytes (4 SHA-1 output blocks)
+    group.bench_function("aes256_one_password", |b| {
+        let mut out = [0u8; 66];
+        b.iter(|| {
+            pbkdf2::pbkdf2::<Hmac<Sha1>>(black_box(password), &salt, 1000, &mut out).unwrap();
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_pbkdf2);
+criterion_main!(benches);

--- a/benches/pbkdf2_gpu.rs
+++ b/benches/pbkdf2_gpu.rs
@@ -1,0 +1,66 @@
+use criterion::{Criterion, Throughput, criterion_group, criterion_main};
+use std::hint::black_box;
+use zip_password_finder::gpu::GpuContext;
+use zip_password_finder::gpu::pbkdf2::Pbkdf2Context;
+
+const MAX_BATCH: u32 = 65_536;
+const MAX_N_BLOCKS: u32 = 4; // AES-256 derived key = 4 SHA-1 output blocks
+
+// Bigger batches were measured up to 524 288 and showed only ~10% headroom
+// past 65 k for AES-256 (+7% for AES-128) before plateauing entirely.
+// Not worth the run-time hit on a routine bench.
+
+fn bench_pbkdf2_gpu(c: &mut Criterion) {
+    let gpu = match GpuContext::init_blocking() {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("skipping GPU benches: {e}");
+            return;
+        }
+    };
+    eprintln!("GPU: {} ({})", gpu.adapter_name, gpu.backend);
+
+    // Persistent context: pipeline, buffers, bind group built once.
+    let pctx = Pbkdf2Context::new(&gpu, MAX_BATCH, MAX_N_BLOCKS).expect("Pbkdf2Context::new");
+
+    let salt = [0u8; 16];
+    let mut group = c.benchmark_group("pbkdf2_hmac_sha1_1000_gpu_aes256");
+    group.sample_size(20);
+    for batch in [256u32, 1024, 4096, 16384, 65536] {
+        let owned: Vec<Vec<u8>> = (0..batch)
+            .map(|i| format!("password_{i}").into_bytes())
+            .collect();
+        let pws: Vec<&[u8]> = owned.iter().map(Vec::as_slice).collect();
+
+        group.throughput(Throughput::Elements(batch as u64));
+        group.bench_function(format!("batch_{batch}"), |b| {
+            b.iter(|| {
+                let keys = pctx.derive(&pws, &salt, 1000, 66).unwrap();
+                black_box(keys);
+            });
+        });
+    }
+    group.finish();
+
+    let mut group = c.benchmark_group("pbkdf2_hmac_sha1_1000_gpu_aes128");
+    group.sample_size(20);
+    let salt = [0u8; 8];
+    for batch in [4096u32, 16384, 65536] {
+        let owned: Vec<Vec<u8>> = (0..batch)
+            .map(|i| format!("password_{i}").into_bytes())
+            .collect();
+        let pws: Vec<&[u8]> = owned.iter().map(Vec::as_slice).collect();
+
+        group.throughput(Throughput::Elements(batch as u64));
+        group.bench_function(format!("batch_{batch}"), |b| {
+            b.iter(|| {
+                let keys = pctx.derive(&pws, &salt, 1000, 34).unwrap();
+                black_box(keys);
+            });
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_pbkdf2_gpu);
+criterion_main!(benches);

--- a/src/args.rs
+++ b/src/args.rs
@@ -142,10 +142,9 @@ fn command() -> Command {
         .arg(
             Arg::new("gpuBatchSize")
                 .value_parser(value_parser!(u32))
-                .help("GPU batch size, passwords per dispatch (only used with --gpu). Larger values can lift throughput on discrete GPUs (try 65536 or 262144); the 16384 default is tuned for integrated GPUs.")
+                .help("override the GPU batch size (passwords per dispatch). When omitted, a value is picked automatically from the GPU type. Only used with --gpu.")
                 .long("gpuBatchSize")
                 .num_args(1)
-                .default_value("16384")
                 .required(false),
         )
 }
@@ -163,7 +162,7 @@ pub struct Arguments {
     pub custom_charsets: CustomCharsets,
     pub use_gpu: bool,
     pub gpu_smoke_test: bool,
-    pub gpu_batch_size: u32,
+    pub gpu_batch_size: Option<u32>,
 }
 
 pub fn get_args() -> Result<Arguments, FinderError> {
@@ -301,8 +300,10 @@ pub fn get_args() -> Result<Arguments, FinderError> {
     let use_gpu = matches.get_flag("gpu");
     let gpu_smoke_test = matches.get_flag("gpuSmokeTest");
 
-    let gpu_batch_size: &u32 = matches.get_one("gpuBatchSize").expect("impossible");
-    if *gpu_batch_size == 0 {
+    let gpu_batch_size: Option<&u32> = matches.try_get_one("gpuBatchSize")?;
+    if let Some(&v) = gpu_batch_size
+        && v == 0
+    {
         return Err(CliArgumentError {
             message: "'gpuBatchSize' must be positive".to_string(),
         });
@@ -321,7 +322,7 @@ pub fn get_args() -> Result<Arguments, FinderError> {
         custom_charsets,
         use_gpu,
         gpu_smoke_test,
-        gpu_batch_size: *gpu_batch_size,
+        gpu_batch_size: gpu_batch_size.copied(),
     })
 }
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -2,7 +2,7 @@ use crate::charsets::{CharsetChoice, charset_from_choice};
 use crate::finder_errors::FinderError;
 use crate::finder_errors::FinderError::CliArgumentError;
 use crate::password_mask::{CustomCharsets, parse_custom_charset};
-use clap::{Arg, Command};
+use clap::{Arg, ArgAction, Command};
 use clap::{crate_authors, crate_description, crate_name, crate_version, value_parser};
 use std::path::Path;
 
@@ -17,7 +17,7 @@ fn command() -> Command {
                 .long("inputFile")
                 .short('i')
                 .num_args(1)
-                .required(true),
+                .required_unless_present("gpuSmokeTest"),
         )
         .arg(
             Arg::new("workers")
@@ -126,10 +126,23 @@ fn command() -> Command {
                 .num_args(1)
                 .required(false),
         )
+        .arg(
+            Arg::new("gpu")
+                .help("use the GPU (Vulkan/Metal/DX12 via wgpu) — requires AES-encrypted archive")
+                .long("gpu")
+                .short('g')
+                .action(ArgAction::SetTrue),
+        )
+        .arg(
+            Arg::new("gpuSmokeTest")
+                .help("list GPU adapters and run a trivial compute kernel, then exit (does not require --inputFile)")
+                .long("gpu-smoke-test")
+                .action(ArgAction::SetTrue),
+        )
 }
 
 pub struct Arguments {
-    pub input_file: String,
+    pub input_file: Option<String>,
     pub workers: Option<usize>,
     pub charset_choice: CharsetChoice,
     pub min_password_len: usize,
@@ -139,14 +152,18 @@ pub struct Arguments {
     pub starting_password: Option<String>,
     pub mask: Option<String>,
     pub custom_charsets: CustomCharsets,
+    pub use_gpu: bool,
+    pub gpu_smoke_test: bool,
 }
 
 pub fn get_args() -> Result<Arguments, FinderError> {
     let command = command();
     let matches = command.get_matches();
 
-    let input_file: &String = matches.get_one("inputFile").expect("impossible");
-    if !Path::new(input_file).is_file() {
+    let input_file: Option<&String> = matches.try_get_one("inputFile")?;
+    if let Some(path) = input_file
+        && !Path::new(path).is_file()
+    {
         return Err(CliArgumentError {
             message: "'inputFile' does not exist".to_string(),
         });
@@ -271,8 +288,11 @@ pub fn get_args() -> Result<Arguments, FinderError> {
         }
     }
 
+    let use_gpu = matches.get_flag("gpu");
+    let gpu_smoke_test = matches.get_flag("gpuSmokeTest");
+
     Ok(Arguments {
-        input_file: input_file.clone(),
+        input_file: input_file.cloned(),
         workers: workers.copied(),
         charset_choice,
         min_password_len: *min_password_len,
@@ -282,6 +302,8 @@ pub fn get_args() -> Result<Arguments, FinderError> {
         starting_password: starting_password.cloned(),
         mask: mask.cloned(),
         custom_charsets,
+        use_gpu,
+        gpu_smoke_test,
     })
 }
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -139,6 +139,15 @@ fn command() -> Command {
                 .long("gpu-smoke-test")
                 .action(ArgAction::SetTrue),
         )
+        .arg(
+            Arg::new("gpuBatchSize")
+                .value_parser(value_parser!(u32))
+                .help("GPU batch size, passwords per dispatch (only used with --gpu). Larger values can lift throughput on discrete GPUs (try 65536 or 262144); the 16384 default is tuned for integrated GPUs.")
+                .long("gpuBatchSize")
+                .num_args(1)
+                .default_value("16384")
+                .required(false),
+        )
 }
 
 pub struct Arguments {
@@ -154,6 +163,7 @@ pub struct Arguments {
     pub custom_charsets: CustomCharsets,
     pub use_gpu: bool,
     pub gpu_smoke_test: bool,
+    pub gpu_batch_size: u32,
 }
 
 pub fn get_args() -> Result<Arguments, FinderError> {
@@ -291,6 +301,13 @@ pub fn get_args() -> Result<Arguments, FinderError> {
     let use_gpu = matches.get_flag("gpu");
     let gpu_smoke_test = matches.get_flag("gpuSmokeTest");
 
+    let gpu_batch_size: &u32 = matches.get_one("gpuBatchSize").expect("impossible");
+    if *gpu_batch_size == 0 {
+        return Err(CliArgumentError {
+            message: "'gpuBatchSize' must be positive".to_string(),
+        });
+    }
+
     Ok(Arguments {
         input_file: input_file.cloned(),
         workers: workers.copied(),
@@ -304,6 +321,7 @@ pub fn get_args() -> Result<Arguments, FinderError> {
         custom_charsets,
         use_gpu,
         gpu_smoke_test,
+        gpu_batch_size: *gpu_batch_size,
     })
 }
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -11,12 +11,31 @@ fn command() -> Command {
         .version(crate_version!())
         .author(crate_authors!("\n"))
         .about(crate_description!())
+        .after_help(
+            "EXAMPLES:\n\
+             \n  \
+             Brute-force short passwords (default charset is letters+digits):\n  \
+                 zip-password-finder archive.zip --max-password-len 6\n\
+             \n  \
+             Use a dictionary file:\n  \
+                 zip-password-finder archive.zip -p wordlist.txt\n\
+             \n  \
+             Mask attack (3 lowercase letters + 2 digits):\n  \
+                 zip-password-finder archive.zip -m '?l?l?l?d?d'\n\
+             \n  \
+             GPU acceleration (AES archives only):\n  \
+                 zip-password-finder archive.zip --gpu -p wordlist.txt\n\
+             \n  \
+             Check that GPU acceleration is available on this system:\n  \
+                 zip-password-finder --gpu-smoke-test",
+        )
         .arg(
             Arg::new("inputFile")
                 .help("path to the zip or 7z input file")
                 .value_name("file")
                 .index(1)
-                .required(true),
+                // positional, but optional when only probing the GPU
+                .required_unless_present("gpuSmokeTest"),
         )
         .arg(
             Arg::new("workers")
@@ -81,7 +100,14 @@ fn command() -> Command {
         .arg(
             Arg::new("maxPasswordLen")
                 .value_parser(value_parser!(usize))
-                .help("maximum password length")
+                .help("maximum password length to brute-force")
+                .long_help(
+                    "maximum password length to brute-force. With the default 'lud' charset \
+                     (62 chars) the search space grows as 62^N: length 6 ≈ 56 billion candidates \
+                     (hours on GPU), length 8 ≈ 218 trillion (months), length 10 is effectively \
+                     infeasible. Increase this when you suspect a longer password — but expect \
+                     run-time to scale exponentially.",
+                )
                 .value_name("len")
                 .long("max-password-len")
                 .alias("maxPasswordLen")
@@ -178,10 +204,33 @@ fn command() -> Command {
                 .long("json")
                 .action(ArgAction::SetTrue),
         )
+        .arg(
+            Arg::new("gpu")
+                .help("use the GPU (Vulkan/Metal/DX12 via wgpu) — requires AES-encrypted archive")
+                .long("gpu")
+                .short('g')
+                .action(ArgAction::SetTrue),
+        )
+        .arg(
+            Arg::new("gpuSmokeTest")
+                .help("list GPU adapters and run a trivial compute kernel, then exit (does not require an input file)")
+                .long("gpu-smoke-test")
+                .action(ArgAction::SetTrue),
+        )
+        .arg(
+            Arg::new("gpuBatchSize")
+                .value_parser(value_parser!(u32))
+                .help("override the GPU batch size (passwords per dispatch). When omitted, a value is picked automatically from the GPU type. Only used with --gpu.")
+                .value_name("size")
+                .long("gpu-batch-size")
+                .alias("gpuBatchSize")
+                .num_args(1)
+                .required(false),
+        )
 }
 
 pub struct Arguments {
-    pub input_file: String,
+    pub input_file: Option<String>,
     pub workers: Option<usize>,
     pub charset_choice: CharsetChoice,
     pub min_password_len: usize,
@@ -196,16 +245,21 @@ pub struct Arguments {
     pub custom_charsets: CustomCharsets,
     pub quiet: bool,
     pub json: bool,
+    pub use_gpu: bool,
+    pub gpu_smoke_test: bool,
+    pub gpu_batch_size: Option<u32>,
 }
 
 pub fn get_args() -> Result<Arguments, FinderError> {
     let command = command();
     let matches = command.get_matches();
 
-    let input_file: &String = matches.get_one("inputFile").expect("impossible");
-    if !Path::new(input_file).is_file() {
+    let input_file: Option<&String> = matches.try_get_one("inputFile")?;
+    if let Some(path) = input_file
+        && !Path::new(path).is_file()
+    {
         return Err(CliArgumentError {
-            message: format!("input file '{input_file}' does not exist"),
+            message: format!("input file '{path}' does not exist"),
         });
     }
 
@@ -309,8 +363,20 @@ pub fn get_args() -> Result<Arguments, FinderError> {
         }
     }
 
+    let use_gpu = matches.get_flag("gpu");
+    let gpu_smoke_test = matches.get_flag("gpuSmokeTest");
+
+    let gpu_batch_size: Option<&u32> = matches.try_get_one("gpuBatchSize")?;
+    if let Some(&v) = gpu_batch_size
+        && v == 0
+    {
+        return Err(CliArgumentError {
+            message: "'--gpu-batch-size' must be positive".to_string(),
+        });
+    }
+
     Ok(Arguments {
-        input_file: input_file.clone(),
+        input_file: input_file.cloned(),
         workers: workers.copied(),
         charset_choice,
         min_password_len: *min_password_len,
@@ -323,6 +389,9 @@ pub fn get_args() -> Result<Arguments, FinderError> {
         custom_charsets,
         quiet: matches.get_flag("quiet"),
         json: matches.get_flag("json"),
+        use_gpu,
+        gpu_smoke_test,
+        gpu_batch_size: gpu_batch_size.copied(),
     })
 }
 

--- a/src/finder_errors.rs
+++ b/src/finder_errors.rs
@@ -14,6 +14,8 @@ pub enum FinderError {
     ClapError { e: clap::Error },
     #[error("CLI argument match error ({message})")]
     ClapMatchError { message: String },
+    #[error("GPU error - {message}")]
+    Gpu { message: String },
 }
 
 impl FinderError {

--- a/src/finder_errors.rs
+++ b/src/finder_errors.rs
@@ -16,6 +16,8 @@ pub enum FinderError {
     ClapError { e: clap::Error },
     #[error("CLI argument match error ({message})")]
     ClapMatchError { message: String },
+    #[error("GPU error - {message}")]
+    Gpu { message: String },
 }
 
 impl FinderError {

--- a/src/gpu/mod.rs
+++ b/src/gpu/mod.rs
@@ -1,0 +1,248 @@
+use std::borrow::Cow;
+use std::time::Instant;
+
+pub mod pbkdf2;
+pub mod sha1;
+
+pub struct AdapterSummary {
+    pub name: String,
+    pub backend: String,
+    pub device_type: String,
+    pub driver: String,
+    pub driver_info: String,
+}
+
+pub fn list_adapters() -> Vec<AdapterSummary> {
+    pollster::block_on(list_adapters_async())
+}
+
+async fn list_adapters_async() -> Vec<AdapterSummary> {
+    let instance = wgpu::Instance::default();
+    instance
+        .enumerate_adapters(wgpu::Backends::all())
+        .await
+        .into_iter()
+        .map(|adapter| {
+            let info = adapter.get_info();
+            AdapterSummary {
+                name: info.name,
+                backend: format!("{:?}", info.backend),
+                device_type: format!("{:?}", info.device_type),
+                driver: info.driver,
+                driver_info: info.driver_info,
+            }
+        })
+        .collect()
+}
+
+pub struct GpuContext {
+    pub device: wgpu::Device,
+    pub queue: wgpu::Queue,
+    pub adapter_name: String,
+    pub backend: String,
+    pub device_type: String,
+    pub driver: String,
+}
+
+impl GpuContext {
+    pub fn init_blocking() -> Result<Self, String> {
+        pollster::block_on(Self::init())
+    }
+
+    pub async fn init() -> Result<Self, String> {
+        let instance = wgpu::Instance::default();
+        let adapter = instance
+            .request_adapter(&wgpu::RequestAdapterOptions {
+                power_preference: wgpu::PowerPreference::HighPerformance,
+                force_fallback_adapter: false,
+                compatible_surface: None,
+            })
+            .await
+            .map_err(|e| format!("no compatible GPU adapter found: {e}"))?;
+
+        let info = adapter.get_info();
+        let adapter_name = info.name.clone();
+        let backend = format!("{:?}", info.backend);
+        let device_type = format!("{:?}", info.device_type);
+        let driver = format!("{} ({})", info.driver, info.driver_info);
+
+        let (device, queue) = adapter
+            .request_device(&wgpu::DeviceDescriptor {
+                label: Some("zip-password-finder"),
+                required_features: wgpu::Features::empty(),
+                required_limits: wgpu::Limits::downlevel_defaults(),
+                memory_hints: wgpu::MemoryHints::Performance,
+                experimental_features: wgpu::ExperimentalFeatures::disabled(),
+                trace: wgpu::Trace::Off,
+            })
+            .await
+            .map_err(|e| format!("request_device failed: {e}"))?;
+
+        Ok(Self {
+            device,
+            queue,
+            adapter_name,
+            backend,
+            device_type,
+            driver,
+        })
+    }
+}
+
+pub struct SmokeTestReport {
+    pub adapter_name: String,
+    pub backend: String,
+    pub device_type: String,
+    pub driver: String,
+    pub elements_processed: usize,
+    pub elapsed_ms: f64,
+}
+
+pub fn smoke_test() -> Result<SmokeTestReport, String> {
+    let ctx = GpuContext::init_blocking()?;
+    pollster::block_on(smoke_test_async(&ctx))
+}
+
+async fn smoke_test_async(ctx: &GpuContext) -> Result<SmokeTestReport, String> {
+    use wgpu::util::DeviceExt;
+
+    const N: usize = 1024 * 16;
+    let input: Vec<u32> = (0..N as u32).collect();
+    let bytes: &[u8] = bytemuck::cast_slice(&input);
+
+    let storage = ctx
+        .device
+        .create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("smoke-test-storage"),
+            contents: bytes,
+            usage: wgpu::BufferUsages::STORAGE
+                | wgpu::BufferUsages::COPY_DST
+                | wgpu::BufferUsages::COPY_SRC,
+        });
+
+    let staging = ctx.device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("smoke-test-staging"),
+        size: bytes.len() as u64,
+        usage: wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::COPY_DST,
+        mapped_at_creation: false,
+    });
+
+    let shader = ctx
+        .device
+        .create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("smoke-test-shader"),
+            source: wgpu::ShaderSource::Wgsl(Cow::Borrowed(include_str!("smoke_test.wgsl"))),
+        });
+
+    let pipeline = ctx
+        .device
+        .create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+            label: Some("smoke-test-pipeline"),
+            layout: None,
+            module: &shader,
+            entry_point: Some("main"),
+            compilation_options: Default::default(),
+            cache: None,
+        });
+
+    let bind_group_layout = pipeline.get_bind_group_layout(0);
+    let bind_group = ctx.device.create_bind_group(&wgpu::BindGroupDescriptor {
+        label: Some("smoke-test-bind-group"),
+        layout: &bind_group_layout,
+        entries: &[wgpu::BindGroupEntry {
+            binding: 0,
+            resource: storage.as_entire_binding(),
+        }],
+    });
+
+    let start = Instant::now();
+    let mut encoder = ctx
+        .device
+        .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("smoke-test-encoder"),
+        });
+    {
+        let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
+            label: Some("smoke-test-pass"),
+            timestamp_writes: None,
+        });
+        pass.set_pipeline(&pipeline);
+        pass.set_bind_group(0, &bind_group, &[]);
+        let workgroups = N.div_ceil(64) as u32;
+        pass.dispatch_workgroups(workgroups, 1, 1);
+    }
+    encoder.copy_buffer_to_buffer(&storage, 0, &staging, 0, bytes.len() as u64);
+    ctx.queue.submit(Some(encoder.finish()));
+
+    let buffer_slice = staging.slice(..);
+    let (sender, receiver) = std::sync::mpsc::channel();
+    buffer_slice.map_async(wgpu::MapMode::Read, move |result| {
+        let _ = sender.send(result);
+    });
+
+    ctx.device
+        .poll(wgpu::PollType::wait_indefinitely())
+        .expect("poll");
+
+    receiver
+        .recv()
+        .map_err(|e| format!("map_async channel closed: {e}"))?
+        .map_err(|e| format!("buffer map failed: {e}"))?;
+
+    let mapped = buffer_slice.get_mapped_range();
+    let result: &[u32] = bytemuck::cast_slice(&mapped);
+    for (i, &v) in result.iter().enumerate() {
+        let expected = i as u32 + 1;
+        if v != expected {
+            return Err(format!(
+                "kernel produced wrong result at index {i}: expected {expected}, got {v}"
+            ));
+        }
+    }
+
+    let elapsed = start.elapsed();
+    drop(mapped);
+    staging.unmap();
+
+    Ok(SmokeTestReport {
+        adapter_name: ctx.adapter_name.clone(),
+        backend: ctx.backend.clone(),
+        device_type: ctx.device_type.clone(),
+        driver: ctx.driver.clone(),
+        elements_processed: N,
+        elapsed_ms: elapsed.as_secs_f64() * 1000.0,
+    })
+}
+
+pub fn run_smoke_test_cli() -> i32 {
+    println!("Available adapters:");
+    let adapters = list_adapters();
+    if adapters.is_empty() {
+        println!("  (none)");
+    } else {
+        for (i, a) in adapters.iter().enumerate() {
+            println!(
+                "  [{i}] {} | backend={} | type={} | driver={} ({})",
+                a.name, a.backend, a.device_type, a.driver, a.driver_info
+            );
+        }
+    }
+    println!();
+    println!("Running smoke test on highest-performance adapter...");
+    match smoke_test() {
+        Ok(report) => {
+            println!("OK");
+            println!("  adapter:   {}", report.adapter_name);
+            println!("  backend:   {}", report.backend);
+            println!("  type:      {}", report.device_type);
+            println!("  driver:    {}", report.driver);
+            println!("  elements:  {}", report.elements_processed);
+            println!("  dispatch:  {:.3} ms", report.elapsed_ms);
+            0
+        }
+        Err(e) => {
+            eprintln!("FAIL: {e}");
+            1
+        }
+    }
+}

--- a/src/gpu/mod.rs
+++ b/src/gpu/mod.rs
@@ -1,0 +1,301 @@
+use std::borrow::Cow;
+use std::time::Instant;
+
+pub mod pbkdf2;
+pub mod sha1;
+
+pub struct AdapterSummary {
+    pub name: String,
+    pub backend: String,
+    pub device_type: String,
+    pub driver: String,
+    pub driver_info: String,
+}
+
+pub fn list_adapters() -> Vec<AdapterSummary> {
+    pollster::block_on(list_adapters_async())
+}
+
+async fn list_adapters_async() -> Vec<AdapterSummary> {
+    let instance = wgpu::Instance::default();
+    instance
+        .enumerate_adapters(wgpu::Backends::all())
+        .await
+        .into_iter()
+        .map(|adapter| {
+            let info = adapter.get_info();
+            AdapterSummary {
+                name: info.name,
+                backend: format!("{:?}", info.backend),
+                device_type: format!("{:?}", info.device_type),
+                driver: info.driver,
+                driver_info: info.driver_info,
+            }
+        })
+        .collect()
+}
+
+pub struct GpuContext {
+    pub device: wgpu::Device,
+    pub queue: wgpu::Queue,
+    pub adapter_name: String,
+    pub backend: String,
+    pub device_type: String,
+    pub driver: String,
+}
+
+impl GpuContext {
+    pub fn init_blocking() -> Result<Self, String> {
+        pollster::block_on(Self::init())
+    }
+
+    pub async fn init() -> Result<Self, String> {
+        let instance = wgpu::Instance::default();
+        let adapter = instance
+            .request_adapter(&wgpu::RequestAdapterOptions {
+                power_preference: wgpu::PowerPreference::HighPerformance,
+                force_fallback_adapter: false,
+                compatible_surface: None,
+            })
+            .await
+            .map_err(|e| {
+                format!(
+                    "no compatible GPU found ({e}). \
+                     Try `--gpu-smoke-test` to list adapters, or drop `--gpu` to use the CPU."
+                )
+            })?;
+
+        let info = adapter.get_info();
+        let adapter_name = info.name.clone();
+        let backend = format!("{:?}", info.backend);
+        let device_type = format!("{:?}", info.device_type);
+        let driver = format!("{} ({})", info.driver, info.driver_info);
+
+        let (device, queue) = adapter
+            .request_device(&wgpu::DeviceDescriptor {
+                label: Some("zip-password-finder"),
+                required_features: wgpu::Features::empty(),
+                required_limits: wgpu::Limits::downlevel_defaults(),
+                memory_hints: wgpu::MemoryHints::Performance,
+                experimental_features: wgpu::ExperimentalFeatures::disabled(),
+                trace: wgpu::Trace::Off,
+            })
+            .await
+            .map_err(|e| {
+                format!(
+                    "could not initialize the GPU ({e}). \
+                     Drop `--gpu` to use the CPU."
+                )
+            })?;
+
+        Ok(Self {
+            device,
+            queue,
+            adapter_name,
+            backend,
+            device_type,
+            driver,
+        })
+    }
+}
+
+pub struct SmokeTestReport {
+    pub adapter_name: String,
+    pub backend: String,
+    pub device_type: String,
+    pub driver: String,
+    pub elements_processed: usize,
+    pub elapsed_ms: f64,
+}
+
+pub fn smoke_test() -> Result<SmokeTestReport, String> {
+    let ctx = GpuContext::init_blocking()?;
+    pollster::block_on(smoke_test_async(&ctx))
+}
+
+async fn smoke_test_async(ctx: &GpuContext) -> Result<SmokeTestReport, String> {
+    use wgpu::util::DeviceExt;
+
+    const N: usize = 1024 * 16;
+    let input: Vec<u32> = (0..N as u32).collect();
+    let bytes: &[u8] = bytemuck::cast_slice(&input);
+
+    let storage = ctx
+        .device
+        .create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("smoke-test-storage"),
+            contents: bytes,
+            usage: wgpu::BufferUsages::STORAGE
+                | wgpu::BufferUsages::COPY_DST
+                | wgpu::BufferUsages::COPY_SRC,
+        });
+
+    let staging = ctx.device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("smoke-test-staging"),
+        size: bytes.len() as u64,
+        usage: wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::COPY_DST,
+        mapped_at_creation: false,
+    });
+
+    let shader = ctx
+        .device
+        .create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("smoke-test-shader"),
+            source: wgpu::ShaderSource::Wgsl(Cow::Borrowed(include_str!("smoke_test.wgsl"))),
+        });
+
+    let pipeline = ctx
+        .device
+        .create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+            label: Some("smoke-test-pipeline"),
+            layout: None,
+            module: &shader,
+            entry_point: Some("main"),
+            compilation_options: Default::default(),
+            cache: None,
+        });
+
+    let bind_group_layout = pipeline.get_bind_group_layout(0);
+    let bind_group = ctx.device.create_bind_group(&wgpu::BindGroupDescriptor {
+        label: Some("smoke-test-bind-group"),
+        layout: &bind_group_layout,
+        entries: &[wgpu::BindGroupEntry {
+            binding: 0,
+            resource: storage.as_entire_binding(),
+        }],
+    });
+
+    let start = Instant::now();
+    let mut encoder = ctx
+        .device
+        .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("smoke-test-encoder"),
+        });
+    {
+        let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
+            label: Some("smoke-test-pass"),
+            timestamp_writes: None,
+        });
+        pass.set_pipeline(&pipeline);
+        pass.set_bind_group(0, &bind_group, &[]);
+        let workgroups = N.div_ceil(64) as u32;
+        pass.dispatch_workgroups(workgroups, 1, 1);
+    }
+    encoder.copy_buffer_to_buffer(&storage, 0, &staging, 0, bytes.len() as u64);
+    ctx.queue.submit(Some(encoder.finish()));
+
+    let buffer_slice = staging.slice(..);
+    let (sender, receiver) = std::sync::mpsc::channel();
+    buffer_slice.map_async(wgpu::MapMode::Read, move |result| {
+        let _ = sender.send(result);
+    });
+
+    ctx.device
+        .poll(wgpu::PollType::wait_indefinitely())
+        .expect("poll");
+
+    receiver
+        .recv()
+        .map_err(|e| format!("map_async channel closed: {e}"))?
+        .map_err(|e| format!("buffer map failed: {e}"))?;
+
+    let mapped = buffer_slice.get_mapped_range();
+    let result: &[u32] = bytemuck::cast_slice(&mapped);
+    for (i, &v) in result.iter().enumerate() {
+        let expected = i as u32 + 1;
+        if v != expected {
+            return Err(format!(
+                "kernel produced wrong result at index {i}: expected {expected}, got {v}"
+            ));
+        }
+    }
+
+    let elapsed = start.elapsed();
+    drop(mapped);
+    staging.unmap();
+
+    Ok(SmokeTestReport {
+        adapter_name: ctx.adapter_name.clone(),
+        backend: ctx.backend.clone(),
+        device_type: ctx.device_type.clone(),
+        driver: ctx.driver.clone(),
+        elements_processed: N,
+        elapsed_ms: elapsed.as_secs_f64() * 1000.0,
+    })
+}
+
+// Friendlier rendering of `wgpu::DeviceType` Debug strings for the smoke
+// test verdict. Falls through to the raw value for any future variant.
+fn humanize_device_type(t: &str) -> &str {
+    match t {
+        "DiscreteGpu" => "discrete GPU",
+        "IntegratedGpu" => "integrated GPU",
+        "VirtualGpu" => "virtual GPU",
+        "Cpu" => "software (CPU)",
+        "Other" => "other",
+        _ => t,
+    }
+}
+
+pub fn run_smoke_test_cli() -> i32 {
+    println!("Checking GPU acceleration...");
+    println!();
+
+    let adapters = list_adapters();
+    match smoke_test() {
+        Ok(report) => {
+            println!("[OK] GPU acceleration is available.");
+            println!();
+            println!("  Will use:  {}", report.adapter_name);
+            println!(
+                "  Type:      {} ({} backend)",
+                humanize_device_type(&report.device_type),
+                report.backend
+            );
+            println!();
+            println!("  To enable, add --gpu to your command, e.g.:");
+            println!("      zip-password-finder -i archive.zip --gpu -p wordlist.txt");
+
+            if adapters.len() > 1 {
+                println!();
+                println!("All adapters detected (the highest-performance one is used):");
+                for (i, a) in adapters.iter().enumerate() {
+                    println!(
+                        "  [{i}] {} | backend={} | type={} | driver={} ({})",
+                        a.name, a.backend, a.device_type, a.driver, a.driver_info
+                    );
+                }
+            }
+
+            println!();
+            println!(
+                "(Diagnostic: dispatched {} elements in {:.3} ms; driver {})",
+                report.elements_processed, report.elapsed_ms, report.driver
+            );
+            0
+        }
+        Err(e) => {
+            eprintln!("[FAIL] GPU acceleration is NOT available on this system.");
+            eprintln!();
+            eprintln!("  Reason: {e}");
+            eprintln!();
+            eprintln!("Common causes:");
+            eprintln!("  - Headless or SSH session without GPU forwarding");
+            eprintln!("  - WSL or Docker container without GPU passthrough");
+            eprintln!("  - Missing or outdated graphics drivers");
+            eprintln!();
+            eprintln!("The CPU path still works — just run without --gpu.");
+            if !adapters.is_empty() {
+                eprintln!();
+                eprintln!("Adapters that were detected (but not usable for compute):");
+                for (i, a) in adapters.iter().enumerate() {
+                    eprintln!(
+                        "  [{i}] {} | backend={} | type={}",
+                        a.name, a.backend, a.device_type
+                    );
+                }
+            }
+            1
+        }
+    }
+}

--- a/src/gpu/mod.rs
+++ b/src/gpu/mod.rs
@@ -299,3 +299,15 @@ pub fn run_smoke_test_cli() -> i32 {
         }
     }
 }
+
+#[cfg(test)]
+/// One shared GPU context for all tests. Creating a `wgpu` device concurrently
+/// crashes some drivers, and the test harness runs tests in parallel — so the
+/// device is created once (and reused across threads, which `wgpu` allows).
+/// This avoids the crash and is faster than a context per test.
+pub(crate) fn test_context() -> &'static GpuContext {
+    use std::sync::LazyLock;
+    static CTX: LazyLock<GpuContext> =
+        LazyLock::new(|| GpuContext::init_blocking().expect("GPU init for tests"));
+    &CTX
+}

--- a/src/gpu/mod.rs
+++ b/src/gpu/mod.rs
@@ -56,6 +56,7 @@ impl GpuContext {
                 power_preference: wgpu::PowerPreference::HighPerformance,
                 force_fallback_adapter: false,
                 compatible_surface: None,
+                apply_limit_buckets: false,
             })
             .await
             .map_err(|e| {
@@ -199,7 +200,9 @@ async fn smoke_test_async(ctx: &GpuContext) -> Result<SmokeTestReport, String> {
         .map_err(|e| format!("map_async channel closed: {e}"))?
         .map_err(|e| format!("buffer map failed: {e}"))?;
 
-    let mapped = buffer_slice.get_mapped_range();
+    let mapped = buffer_slice
+        .get_mapped_range()
+        .map_err(|e| format!("get_mapped_range failed: {e:?}"))?;
     let result: &[u32] = bytemuck::cast_slice(&mapped);
     for (i, &v) in result.iter().enumerate() {
         let expected = i as u32 + 1;

--- a/src/gpu/pbkdf2.rs
+++ b/src/gpu/pbkdf2.rs
@@ -1,0 +1,462 @@
+use std::borrow::Cow;
+
+use crate::gpu::GpuContext;
+
+pub(crate) const HMAC_BLOCK_BYTES: usize = 64;
+pub(crate) const SHA1_OUTPUT_BYTES: usize = 20;
+pub(crate) const PASSWORD_WORDS: usize = HMAC_BLOCK_BYTES / 4;
+
+// Must match `@workgroup_size(...)` in pbkdf2.wgsl.
+const WORKGROUP_SIZE: u32 = 256;
+
+#[derive(Debug)]
+pub enum PbkdfError {
+    PasswordTooLong { len: usize },
+    SaltTooLong { len: usize },
+    InvalidDerivedKeyLen(usize),
+    Gpu(String),
+}
+
+impl std::fmt::Display for PbkdfError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::PasswordTooLong { len } => write!(
+                f,
+                "password length {len} exceeds {HMAC_BLOCK_BYTES}-byte HMAC block size (long-key path not implemented)"
+            ),
+            Self::SaltTooLong { len } => write!(
+                f,
+                "salt length {len} exceeds 51 bytes (would not fit with block index + padding)"
+            ),
+            Self::InvalidDerivedKeyLen(len) => {
+                write!(f, "invalid derived key length {len}")
+            }
+            Self::Gpu(e) => write!(f, "GPU error: {e}"),
+        }
+    }
+}
+
+/// Pack one zero-padded 64-byte HMAC key block as 16 big-endian u32s.
+pub(crate) fn pack_password(password: &[u8]) -> Result<[u32; PASSWORD_WORDS], PbkdfError> {
+    if password.len() > HMAC_BLOCK_BYTES {
+        return Err(PbkdfError::PasswordTooLong {
+            len: password.len(),
+        });
+    }
+    let mut padded = [0u8; HMAC_BLOCK_BYTES];
+    padded[..password.len()].copy_from_slice(password);
+    let mut out = [0u32; PASSWORD_WORDS];
+    for (i, chunk) in padded.chunks_exact(4).enumerate() {
+        out[i] = u32::from_be_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]);
+    }
+    Ok(out)
+}
+
+/// Pack `n_blocks` U_1 message blocks (one per output block index 1..=n_blocks).
+/// Each block is `salt || i_be32 || 0x80 || zeros || ((64+salt_len+4)*8) as be64`,
+/// padded to 64 bytes and packed as 16 big-endian u32s.
+pub(crate) fn pack_u1_message_blocks(salt: &[u8], n_blocks: u32) -> Result<Vec<u32>, PbkdfError> {
+    // We need salt_len + 4 (block index) + 1 (0x80 marker) + 8 (length) <= 64.
+    if salt.len() > 51 {
+        return Err(PbkdfError::SaltTooLong { len: salt.len() });
+    }
+    let bit_len = ((HMAC_BLOCK_BYTES + salt.len() + 4) * 8) as u64;
+    let mut out = Vec::with_capacity((n_blocks as usize) * 16);
+    for i in 1..=n_blocks {
+        let mut block = [0u8; HMAC_BLOCK_BYTES];
+        block[..salt.len()].copy_from_slice(salt);
+        block[salt.len()..salt.len() + 4].copy_from_slice(&i.to_be_bytes());
+        block[salt.len() + 4] = 0x80;
+        block[56..64].copy_from_slice(&bit_len.to_be_bytes());
+        for chunk in block.chunks_exact(4) {
+            out.push(u32::from_be_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]));
+        }
+    }
+    Ok(out)
+}
+
+/// Persistent PBKDF2 worker — pre-allocates GPU buffers and compiles the
+/// pipeline once, so per-batch cost is just one `queue.write_buffer` per input
+/// + one dispatch + one readback. Use this from a worker thread.
+pub struct Pbkdf2Context<'gpu> {
+    gpu: &'gpu GpuContext,
+    pipeline: wgpu::ComputePipeline,
+    bind_group: wgpu::BindGroup,
+    pwd_buf: wgpu::Buffer,
+    u1_buf: wgpu::Buffer,
+    dk_buf: wgpu::Buffer,
+    params_buf: wgpu::Buffer,
+    staging: wgpu::Buffer,
+    max_batch: u32,
+    max_n_blocks: u32,
+}
+
+impl<'gpu> Pbkdf2Context<'gpu> {
+    /// Build a persistent PBKDF2 worker bound to `gpu`.
+    ///
+    /// Pre-allocates the password / U_1 / derived-key / params / staging
+    /// buffers to fit any dispatch up to `max_batch` candidates with a
+    /// derived-key length producing up to `max_n_blocks` SHA-1 output blocks
+    /// (i.e. `derived_key_len <= max_n_blocks * 20` bytes), compiles the WGSL
+    /// pipeline once, and builds the bind group. Subsequent calls to
+    /// [`derive`](Self::derive) reuse all of it.
+    ///
+    /// `max_batch` and `max_n_blocks` are hard caps for any single call to
+    /// [`derive`](Self::derive). Exceeding either returns
+    /// [`PbkdfError::Gpu`].
+    ///
+    /// For WinZip-AES the relevant `max_n_blocks` values are 2 (AES-128, 34-
+    /// byte derived key), 3 (AES-192, 50 bytes), or 4 (AES-256, 66 bytes).
+    ///
+    /// # Errors
+    /// Returns [`PbkdfError::Gpu`] if `max_batch == 0` or `max_n_blocks == 0`.
+    pub fn new(
+        gpu: &'gpu GpuContext,
+        max_batch: u32,
+        max_n_blocks: u32,
+    ) -> Result<Self, PbkdfError> {
+        if max_batch == 0 {
+            return Err(PbkdfError::Gpu("max_batch must be > 0".into()));
+        }
+        if max_n_blocks == 0 {
+            return Err(PbkdfError::Gpu("max_n_blocks must be > 0".into()));
+        }
+
+        let device = &gpu.device;
+
+        let pwd_bytes = (max_batch as u64) * (HMAC_BLOCK_BYTES as u64);
+        let u1_bytes = (max_n_blocks as u64) * (HMAC_BLOCK_BYTES as u64);
+        let dk_bytes = (max_batch as u64) * (max_n_blocks as u64) * (SHA1_OUTPUT_BYTES as u64);
+
+        let pwd_buf = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("pbkdf2-passwords"),
+            size: pwd_bytes,
+            usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+        let u1_buf = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("pbkdf2-u1-blocks"),
+            size: u1_bytes,
+            usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+        let dk_buf = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("pbkdf2-derived-keys"),
+            size: dk_bytes,
+            usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_SRC,
+            mapped_at_creation: false,
+        });
+        let params_buf = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("pbkdf2-params"),
+            size: 16,
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+        let staging = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("pbkdf2-staging"),
+            size: dk_bytes,
+            usage: wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+
+        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("pbkdf2-shader"),
+            source: wgpu::ShaderSource::Wgsl(Cow::Borrowed(include_str!("pbkdf2.wgsl"))),
+        });
+        let pipeline = device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+            label: Some("pbkdf2-pipeline"),
+            layout: None,
+            module: &shader,
+            entry_point: Some("main"),
+            compilation_options: Default::default(),
+            cache: None,
+        });
+
+        let bgl = pipeline.get_bind_group_layout(0);
+        let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("pbkdf2-bind-group"),
+            layout: &bgl,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: pwd_buf.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: u1_buf.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 2,
+                    resource: dk_buf.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 3,
+                    resource: params_buf.as_entire_binding(),
+                },
+            ],
+        });
+
+        Ok(Self {
+            gpu,
+            pipeline,
+            bind_group,
+            pwd_buf,
+            u1_buf,
+            dk_buf,
+            params_buf,
+            staging,
+            max_batch,
+            max_n_blocks,
+        })
+    }
+
+    /// Derive PBKDF2-HMAC-SHA1 keys for `passwords` in a single GPU dispatch.
+    ///
+    /// All passwords share `salt`, `iterations`, and `derived_key_len`.
+    /// WinZip-AES fixes `iterations` to 1000.
+    ///
+    /// Returns one `Vec<u8>` per input password, each of length
+    /// `derived_key_len`. The output `Vec` is in the same order as the input
+    /// slice, so `output[i]` is the derived key for `passwords[i]`.
+    ///
+    /// Blocks the calling thread until the GPU dispatch completes and the
+    /// output is mapped back to host memory.
+    ///
+    /// # Errors
+    /// - [`PbkdfError::PasswordTooLong`] if any password exceeds 64 bytes
+    ///   (HMAC long-key path is not implemented).
+    /// - [`PbkdfError::SaltTooLong`] if `salt` exceeds 51 bytes (would not fit
+    ///   in a single SHA-1 block alongside the block index and padding).
+    /// - [`PbkdfError::InvalidDerivedKeyLen`] if `derived_key_len == 0`.
+    /// - [`PbkdfError::Gpu`] if the batch size or required block count
+    ///   exceeds the bounds set in [`new`](Self::new), or if a wgpu buffer
+    ///   mapping fails.
+    pub fn derive(
+        &self,
+        passwords: &[&[u8]],
+        salt: &[u8],
+        iterations: u32,
+        derived_key_len: usize,
+    ) -> Result<Vec<Vec<u8>>, PbkdfError> {
+        if derived_key_len == 0 {
+            return Err(PbkdfError::InvalidDerivedKeyLen(0));
+        }
+        let n_blocks = derived_key_len.div_ceil(SHA1_OUTPUT_BYTES) as u32;
+        let n_passwords = passwords.len() as u32;
+        if n_passwords == 0 {
+            return Ok(Vec::new());
+        }
+        if n_passwords > self.max_batch {
+            return Err(PbkdfError::Gpu(format!(
+                "batch size {n_passwords} exceeds context max_batch {}",
+                self.max_batch
+            )));
+        }
+        if n_blocks > self.max_n_blocks {
+            return Err(PbkdfError::Gpu(format!(
+                "derived_key_len needs {n_blocks} output blocks, exceeds context max_n_blocks {}",
+                self.max_n_blocks
+            )));
+        }
+
+        // Pack inputs and stream them into the persistent buffers.
+        let mut packed_passwords = Vec::with_capacity(passwords.len() * PASSWORD_WORDS);
+        for pw in passwords {
+            let p = pack_password(pw)?;
+            packed_passwords.extend_from_slice(&p);
+        }
+        let u1_blocks = pack_u1_message_blocks(salt, n_blocks)?;
+        let params = [n_passwords, n_blocks, iterations, 0u32];
+
+        self.gpu
+            .queue
+            .write_buffer(&self.pwd_buf, 0, bytemuck::cast_slice(&packed_passwords));
+        self.gpu
+            .queue
+            .write_buffer(&self.u1_buf, 0, bytemuck::cast_slice(&u1_blocks));
+        self.gpu
+            .queue
+            .write_buffer(&self.params_buf, 0, bytemuck::cast_slice(&params));
+
+        let dk_words_per_password = (n_blocks as usize) * 5;
+        let dk_used_bytes = (passwords.len() * dk_words_per_password * 4) as u64;
+
+        let mut encoder = self
+            .gpu
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                label: Some("pbkdf2-encoder"),
+            });
+        {
+            let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
+                label: Some("pbkdf2-pass"),
+                timestamp_writes: None,
+            });
+            pass.set_pipeline(&self.pipeline);
+            pass.set_bind_group(0, &self.bind_group, &[]);
+            let workgroups = (n_passwords as usize).div_ceil(WORKGROUP_SIZE as usize) as u32;
+            pass.dispatch_workgroups(workgroups, 1, 1);
+        }
+        encoder.copy_buffer_to_buffer(&self.dk_buf, 0, &self.staging, 0, dk_used_bytes);
+        self.gpu.queue.submit(Some(encoder.finish()));
+
+        // Read back.
+        let slice = self.staging.slice(..dk_used_bytes);
+        let (sender, receiver) = std::sync::mpsc::channel();
+        slice.map_async(wgpu::MapMode::Read, move |r| {
+            let _ = sender.send(r);
+        });
+        self.gpu
+            .device
+            .poll(wgpu::PollType::wait_indefinitely())
+            .map_err(|e| PbkdfError::Gpu(format!("poll failed: {e:?}")))?;
+        receiver
+            .recv()
+            .map_err(|e| PbkdfError::Gpu(format!("map_async channel closed: {e}")))?
+            .map_err(|e| PbkdfError::Gpu(format!("buffer map failed: {e}")))?;
+
+        let mapped = slice.get_mapped_range();
+        let dk_words: &[u32] = bytemuck::cast_slice(&mapped);
+
+        let mut out: Vec<Vec<u8>> = Vec::with_capacity(passwords.len());
+        let block_bytes = (n_blocks as usize) * SHA1_OUTPUT_BYTES;
+        for pid in 0..passwords.len() {
+            let mut full = Vec::with_capacity(block_bytes);
+            let off = pid * dk_words_per_password;
+            for w in 0..dk_words_per_password {
+                full.extend_from_slice(&dk_words[off + w].to_be_bytes());
+            }
+            full.truncate(derived_key_len);
+            out.push(full);
+        }
+        drop(mapped);
+        self.staging.unmap();
+
+        Ok(out)
+    }
+}
+
+/// One-shot wrapper: builds a fresh `Pbkdf2Context` sized for this exact call.
+/// Test-only — production code paths reuse `Pbkdf2Context` directly.
+#[cfg(test)]
+fn pbkdf2_hmac_sha1_gpu(
+    ctx: &GpuContext,
+    passwords: &[&[u8]],
+    salt: &[u8],
+    iterations: u32,
+    derived_key_len: usize,
+) -> Result<Vec<Vec<u8>>, PbkdfError> {
+    if passwords.is_empty() {
+        return Ok(Vec::new());
+    }
+    let n_blocks = derived_key_len.div_ceil(SHA1_OUTPUT_BYTES).max(1) as u32;
+    let pctx = Pbkdf2Context::new(ctx, passwords.len() as u32, n_blocks)?;
+    pctx.derive(passwords, salt, iterations, derived_key_len)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hmac::Hmac;
+    use sha1::Sha1;
+
+    fn cpu(password: &[u8], salt: &[u8], iterations: u32, dk_len: usize) -> Vec<u8> {
+        let mut out = vec![0u8; dk_len];
+        pbkdf2::pbkdf2::<Hmac<Sha1>>(password, salt, iterations, &mut out).unwrap();
+        out
+    }
+
+    fn check_one(password: &[u8], salt: &[u8], iterations: u32, dk_len: usize) {
+        let ctx = GpuContext::init_blocking().expect("GPU init");
+        let pws: &[&[u8]] = &[password];
+        let gpu = pbkdf2_hmac_sha1_gpu(&ctx, pws, salt, iterations, dk_len).expect("gpu pbkdf2");
+        let ref_key = cpu(password, salt, iterations, dk_len);
+        assert_eq!(
+            gpu[0],
+            ref_key,
+            "mismatch for pw={password:?} salt_len={} iter={iterations} dk_len={dk_len}\n  gpu = {:02x?}\n  cpu = {:02x?}",
+            salt.len(),
+            gpu[0],
+            ref_key
+        );
+    }
+
+    #[test]
+    fn pbkdf2_short_password_aes128() {
+        // AES-128: derived_key_length = 2*16 + 2 = 34 bytes, salt = 8 bytes.
+        check_one(b"password", &[1u8; 8], 1000, 34);
+    }
+
+    #[test]
+    fn pbkdf2_short_password_aes192() {
+        // AES-192: derived_key_length = 2*24 + 2 = 50 bytes, salt = 12 bytes.
+        check_one(b"password", &[2u8; 12], 1000, 50);
+    }
+
+    #[test]
+    fn pbkdf2_short_password_aes256() {
+        // AES-256: derived_key_length = 2*32 + 2 = 66 bytes, salt = 16 bytes.
+        check_one(b"password", &[3u8; 16], 1000, 66);
+    }
+
+    #[test]
+    fn pbkdf2_empty_password() {
+        check_one(b"", &[7u8; 16], 1000, 66);
+    }
+
+    #[test]
+    fn pbkdf2_one_iteration() {
+        check_one(b"hello", &[0xAA; 16], 1, 66);
+    }
+
+    #[test]
+    fn pbkdf2_low_iteration_count() {
+        check_one(b"hello", &[0xAA; 16], 100, 66);
+    }
+
+    #[test]
+    fn pbkdf2_password_exactly_64_bytes() {
+        let pw = [b'x'; 64];
+        check_one(&pw, &[0x55; 16], 1000, 66);
+    }
+
+    #[test]
+    fn pbkdf2_varied_salt_lengths() {
+        for salt_len in [1, 4, 7, 8, 11, 12, 15, 16, 20, 32, 51] {
+            let salt: Vec<u8> = (0..salt_len as u8).collect();
+            check_one(b"password", &salt, 1000, 66);
+        }
+    }
+
+    #[test]
+    fn pbkdf2_batched_passwords() {
+        let ctx = GpuContext::init_blocking().expect("GPU init");
+        let salt = [0x42u8; 16];
+        let owned: Vec<Vec<u8>> = (0..256u32)
+            .map(|i| format!("password_{i}").into_bytes())
+            .collect();
+        let pws: Vec<&[u8]> = owned.iter().map(Vec::as_slice).collect();
+        let gpu = pbkdf2_hmac_sha1_gpu(&ctx, &pws, &salt, 1000, 66).expect("gpu pbkdf2");
+        for (i, pw) in owned.iter().enumerate() {
+            let ref_key = cpu(pw, &salt, 1000, 66);
+            assert_eq!(gpu[i], ref_key, "mismatch at index {i} for password {pw:?}");
+        }
+    }
+
+    #[test]
+    fn pbkdf2_batched_partially_filling_workgroup() {
+        // Sizes that don't align to the kernel's workgroup_size.
+        for n in [1, 2, 7, 63, 64, 65, 100, 257] {
+            let ctx = GpuContext::init_blocking().expect("GPU init");
+            let salt = [0xAA; 16];
+            let owned: Vec<Vec<u8>> = (0..n).map(|i| format!("p_{i}").into_bytes()).collect();
+            let pws: Vec<&[u8]> = owned.iter().map(Vec::as_slice).collect();
+            let gpu = pbkdf2_hmac_sha1_gpu(&ctx, &pws, &salt, 1000, 66).expect("gpu pbkdf2");
+            assert_eq!(gpu.len(), n);
+            for (i, pw) in owned.iter().enumerate() {
+                let ref_key = cpu(pw, &salt, 1000, 66);
+                assert_eq!(gpu[i], ref_key, "mismatch at n={n} index {i}");
+            }
+        }
+    }
+}

--- a/src/gpu/pbkdf2.rs
+++ b/src/gpu/pbkdf2.rs
@@ -315,7 +315,9 @@ impl<'gpu> Pbkdf2Context<'gpu> {
             .map_err(|e| PbkdfError::Gpu(format!("map_async channel closed: {e}")))?
             .map_err(|e| PbkdfError::Gpu(format!("buffer map failed: {e}")))?;
 
-        let mapped = slice.get_mapped_range();
+        let mapped = slice
+            .get_mapped_range()
+            .map_err(|e| PbkdfError::Gpu(format!("get_mapped_range failed: {e:?}")))?;
         let dk_words: &[u32] = bytemuck::cast_slice(&mapped);
 
         let mut out: Vec<Vec<u8>> = Vec::with_capacity(passwords.len());

--- a/src/gpu/pbkdf2.rs
+++ b/src/gpu/pbkdf2.rs
@@ -367,9 +367,9 @@ mod tests {
     }
 
     fn check_one(password: &[u8], salt: &[u8], iterations: u32, dk_len: usize) {
-        let ctx = GpuContext::init_blocking().expect("GPU init");
+        let ctx = crate::gpu::test_context();
         let pws: &[&[u8]] = &[password];
-        let gpu = pbkdf2_hmac_sha1_gpu(&ctx, pws, salt, iterations, dk_len).expect("gpu pbkdf2");
+        let gpu = pbkdf2_hmac_sha1_gpu(ctx, pws, salt, iterations, dk_len).expect("gpu pbkdf2");
         let ref_key = cpu(password, salt, iterations, dk_len);
         assert_eq!(
             gpu[0],
@@ -430,13 +430,13 @@ mod tests {
 
     #[test]
     fn pbkdf2_batched_passwords() {
-        let ctx = GpuContext::init_blocking().expect("GPU init");
+        let ctx = crate::gpu::test_context();
         let salt = [0x42u8; 16];
         let owned: Vec<Vec<u8>> = (0..256u32)
             .map(|i| format!("password_{i}").into_bytes())
             .collect();
         let pws: Vec<&[u8]> = owned.iter().map(Vec::as_slice).collect();
-        let gpu = pbkdf2_hmac_sha1_gpu(&ctx, &pws, &salt, 1000, 66).expect("gpu pbkdf2");
+        let gpu = pbkdf2_hmac_sha1_gpu(ctx, &pws, &salt, 1000, 66).expect("gpu pbkdf2");
         for (i, pw) in owned.iter().enumerate() {
             let ref_key = cpu(pw, &salt, 1000, 66);
             assert_eq!(gpu[i], ref_key, "mismatch at index {i} for password {pw:?}");
@@ -447,11 +447,11 @@ mod tests {
     fn pbkdf2_batched_partially_filling_workgroup() {
         // Sizes that don't align to the kernel's workgroup_size.
         for n in [1, 2, 7, 63, 64, 65, 100, 257] {
-            let ctx = GpuContext::init_blocking().expect("GPU init");
+            let ctx = crate::gpu::test_context();
             let salt = [0xAA; 16];
             let owned: Vec<Vec<u8>> = (0..n).map(|i| format!("p_{i}").into_bytes()).collect();
             let pws: Vec<&[u8]> = owned.iter().map(Vec::as_slice).collect();
-            let gpu = pbkdf2_hmac_sha1_gpu(&ctx, &pws, &salt, 1000, 66).expect("gpu pbkdf2");
+            let gpu = pbkdf2_hmac_sha1_gpu(ctx, &pws, &salt, 1000, 66).expect("gpu pbkdf2");
             assert_eq!(gpu.len(), n);
             for (i, pw) in owned.iter().enumerate() {
                 let ref_key = cpu(pw, &salt, 1000, 66);

--- a/src/gpu/pbkdf2.wgsl
+++ b/src/gpu/pbkdf2.wgsl
@@ -1,0 +1,205 @@
+// PBKDF2-HMAC-SHA1 kernel. One workgroup-thread per candidate password.
+//
+// Host responsibilities:
+//   - Zero-pad each password to 64 bytes, pack as 16 big-endian u32s.
+//     (Passwords > 64 bytes are not supported; HMAC's "hash long key" path
+//     would have to be added separately. WinZip-AES passwords are well under
+//     this in practice.)
+//   - For each output block index i in 1..=n_blocks, build the U_1 message
+//     block (salt || i_be32 || 0x80 || zeros || bit_length_be64) padded to
+//     64 bytes, packed as 16 big-endian u32s. Upload n_blocks of these.
+//
+// Standard PBKDF2 micro-optimization: the SHA-1 state after compressing the
+// 64-byte ipad block (and likewise opad) depends only on the password, so
+// we compute each once at the top and reuse them across all 2 * iterations
+// HMAC compressions. ~2x fewer SHA-1 compressions vs naive HMAC.
+
+struct Params {
+    n_passwords: u32,
+    n_blocks: u32,
+    iterations: u32,
+    _pad: u32,
+}
+
+@group(0) @binding(0) var<storage, read> passwords: array<u32>;
+@group(0) @binding(1) var<storage, read> u1_msg_blocks: array<u32>;
+@group(0) @binding(2) var<storage, read_write> derived_keys: array<u32>;
+@group(0) @binding(3) var<uniform> params: Params;
+
+const SHA1_H0: u32 = 0x67452301u;
+const SHA1_H1: u32 = 0xEFCDAB89u;
+const SHA1_H2: u32 = 0x98BADCFEu;
+const SHA1_H3: u32 = 0x10325476u;
+const SHA1_H4: u32 = 0xC3D2E1F0u;
+
+// (64 ipad/opad bytes + 20 inner-hash bytes) * 8 = 672 bits. Constant for
+// every HMAC inner/outer compression after the first message-block.
+const HMAC_INNER_BIT_LEN: u32 = 672u;
+
+// Naga keeps named struct fields as scalars (SROA), whereas `array<u32, 5>`
+// can end up backed by an addressable allocation when ptr<function, _> is
+// taken; using a struct here makes the SROA reliable.
+struct Sha1State {
+    h0: u32,
+    h1: u32,
+    h2: u32,
+    h3: u32,
+    h4: u32,
+}
+
+fn rotl(x: u32, n: u32) -> u32 {
+    return (x << n) | (x >> (32u - n));
+}
+
+fn sha1_compress(state: ptr<function, Sha1State>, block: ptr<function, array<u32, 16>>) {
+    // Rolling 16-word window: W[i] depends only on W[i-3], W[i-8], W[i-14],
+    // W[i-16], so we keep just 16 slots and index by `i & 15`. Cuts VGPR
+    // footprint vs. an explicit `array<u32, 80>`.
+    var w: array<u32, 16>;
+
+    var a = (*state).h0;
+    var b = (*state).h1;
+    var c = (*state).h2;
+    var d = (*state).h3;
+    var e = (*state).h4;
+
+    for (var i: u32 = 0u; i < 80u; i = i + 1u) {
+        let idx = i & 15u;
+        var word: u32;
+        if (i < 16u) {
+            word = (*block)[i];
+        } else {
+            // The four reads are W[i-3], W[i-8], W[i-14], W[i-16]; the last
+            // collides with `idx` (where we'll write) but is read first.
+            word = rotl(
+                w[(i + 13u) & 15u] ^ w[(i + 8u) & 15u] ^ w[(i + 2u) & 15u] ^ w[idx],
+                1u,
+            );
+        }
+        w[idx] = word;
+
+        var f: u32;
+        var k: u32;
+        if (i < 20u) {
+            f = (b & c) | ((~b) & d);
+            k = 0x5A827999u;
+        } else if (i < 40u) {
+            f = b ^ c ^ d;
+            k = 0x6ED9EBA1u;
+        } else if (i < 60u) {
+            f = (b & c) | (b & d) | (c & d);
+            k = 0x8F1BBCDCu;
+        } else {
+            f = b ^ c ^ d;
+            k = 0xCA62C1D6u;
+        }
+        let t = rotl(a, 5u) + f + e + k + word;
+        e = d;
+        d = c;
+        c = rotl(b, 30u);
+        b = a;
+        a = t;
+    }
+
+    (*state).h0 = (*state).h0 + a;
+    (*state).h1 = (*state).h1 + b;
+    (*state).h2 = (*state).h2 + c;
+    (*state).h3 = (*state).h3 + d;
+    (*state).h4 = (*state).h4 + e;
+}
+
+// Build the standard 64-byte block that wraps a 20-byte inner hash for HMAC's
+// outer compression (or for any subsequent HMAC iteration's inner compression).
+fn pack_hash_block(hash: ptr<function, Sha1State>, block: ptr<function, array<u32, 16>>) {
+    (*block)[0] = (*hash).h0;
+    (*block)[1] = (*hash).h1;
+    (*block)[2] = (*hash).h2;
+    (*block)[3] = (*hash).h3;
+    (*block)[4] = (*hash).h4;
+    (*block)[5] = 0x80000000u;
+    (*block)[6] = 0u;
+    (*block)[7] = 0u;
+    (*block)[8] = 0u;
+    (*block)[9] = 0u;
+    (*block)[10] = 0u;
+    (*block)[11] = 0u;
+    (*block)[12] = 0u;
+    (*block)[13] = 0u;
+    (*block)[14] = 0u;
+    (*block)[15] = HMAC_INNER_BIT_LEN;
+}
+
+@compute @workgroup_size(256)
+fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
+    let pid = gid.x;
+    if (pid >= params.n_passwords) {
+        return;
+    }
+
+    // 1. Build ipad and opad blocks (password XOR 0x36.. / 0x5C..).
+    var ipad: array<u32, 16>;
+    var opad: array<u32, 16>;
+    let pw_off = pid * 16u;
+    for (var w: u32 = 0u; w < 16u; w = w + 1u) {
+        let word = passwords[pw_off + w];
+        ipad[w] = word ^ 0x36363636u;
+        opad[w] = word ^ 0x5C5C5C5Cu;
+    }
+
+    // 2. Precompute SHA-1 state after one ipad / opad compression.
+    var ipad_state = Sha1State(SHA1_H0, SHA1_H1, SHA1_H2, SHA1_H3, SHA1_H4);
+    sha1_compress(&ipad_state, &ipad);
+
+    var opad_state = Sha1State(SHA1_H0, SHA1_H1, SHA1_H2, SHA1_H3, SHA1_H4);
+    sha1_compress(&opad_state, &opad);
+
+    // 3. For each output block index in 1..=n_blocks: derive T_i and write out.
+    for (var blk: u32 = 0u; blk < params.n_blocks; blk = blk + 1u) {
+        // U_1: HMAC inner = SHA1(ipad || salt || (blk+1)_be32). The host has
+        // pre-built that 64-byte block (after the ipad prefix already absorbed).
+        var u1_block: array<u32, 16>;
+        let msg_off = blk * 16u;
+        for (var w: u32 = 0u; w < 16u; w = w + 1u) {
+            u1_block[w] = u1_msg_blocks[msg_off + w];
+        }
+
+        var inner: Sha1State = ipad_state;
+        sha1_compress(&inner, &u1_block);
+
+        var outer_block: array<u32, 16>;
+        pack_hash_block(&inner, &outer_block);
+
+        var u_curr: Sha1State = opad_state;
+        sha1_compress(&u_curr, &outer_block);
+
+        var t: Sha1State = u_curr;
+
+        // Iterations 2..=iterations.
+        for (var iter: u32 = 1u; iter < params.iterations; iter = iter + 1u) {
+            var inner_msg: array<u32, 16>;
+            pack_hash_block(&u_curr, &inner_msg);
+
+            var i_state: Sha1State = ipad_state;
+            sha1_compress(&i_state, &inner_msg);
+
+            var o_msg: array<u32, 16>;
+            pack_hash_block(&i_state, &o_msg);
+
+            u_curr = opad_state;
+            sha1_compress(&u_curr, &o_msg);
+
+            t.h0 = t.h0 ^ u_curr.h0;
+            t.h1 = t.h1 ^ u_curr.h1;
+            t.h2 = t.h2 ^ u_curr.h2;
+            t.h3 = t.h3 ^ u_curr.h3;
+            t.h4 = t.h4 ^ u_curr.h4;
+        }
+
+        let dk_off = pid * (params.n_blocks * 5u) + blk * 5u;
+        derived_keys[dk_off + 0u] = t.h0;
+        derived_keys[dk_off + 1u] = t.h1;
+        derived_keys[dk_off + 2u] = t.h2;
+        derived_keys[dk_off + 3u] = t.h3;
+        derived_keys[dk_off + 4u] = t.h4;
+    }
+}

--- a/src/gpu/pbkdf2.wgsl
+++ b/src/gpu/pbkdf2.wgsl
@@ -136,57 +136,60 @@ fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
         return;
     }
 
+    // Two reusable 16-word block buffers. Naming each role separately
+    // (ipad, opad, u1_block, outer_block, inner_msg, o_msg) made naga emit
+    // six distinct `var<function>` allocations, pushing NVIDIA threads past
+    // ~100 registers and capping SM occupancy at ~25%. Live-range analysis
+    // shows only two are ever needed at once: block_a holds password- or
+    // message-derived input, block_b holds hash-derived input.
+    var block_a: array<u32, 16>;
+    var block_b: array<u32, 16>;
+
     // 1. Build ipad and opad blocks (password XOR 0x36.. / 0x5C..).
-    var ipad: array<u32, 16>;
-    var opad: array<u32, 16>;
     let pw_off = pid * 16u;
     for (var w: u32 = 0u; w < 16u; w = w + 1u) {
         let word = passwords[pw_off + w];
-        ipad[w] = word ^ 0x36363636u;
-        opad[w] = word ^ 0x5C5C5C5Cu;
+        block_a[w] = word ^ 0x36363636u;
+        block_b[w] = word ^ 0x5C5C5C5Cu;
     }
 
     // 2. Precompute SHA-1 state after one ipad / opad compression.
     var ipad_state = Sha1State(SHA1_H0, SHA1_H1, SHA1_H2, SHA1_H3, SHA1_H4);
-    sha1_compress(&ipad_state, &ipad);
+    sha1_compress(&ipad_state, &block_a);
 
     var opad_state = Sha1State(SHA1_H0, SHA1_H1, SHA1_H2, SHA1_H3, SHA1_H4);
-    sha1_compress(&opad_state, &opad);
+    sha1_compress(&opad_state, &block_b);
 
     // 3. For each output block index in 1..=n_blocks: derive T_i and write out.
     for (var blk: u32 = 0u; blk < params.n_blocks; blk = blk + 1u) {
         // U_1: HMAC inner = SHA1(ipad || salt || (blk+1)_be32). The host has
         // pre-built that 64-byte block (after the ipad prefix already absorbed).
-        var u1_block: array<u32, 16>;
         let msg_off = blk * 16u;
         for (var w: u32 = 0u; w < 16u; w = w + 1u) {
-            u1_block[w] = u1_msg_blocks[msg_off + w];
+            block_a[w] = u1_msg_blocks[msg_off + w];
         }
 
         var inner: Sha1State = ipad_state;
-        sha1_compress(&inner, &u1_block);
+        sha1_compress(&inner, &block_a);
 
-        var outer_block: array<u32, 16>;
-        pack_hash_block(&inner, &outer_block);
+        pack_hash_block(&inner, &block_b);
 
         var u_curr: Sha1State = opad_state;
-        sha1_compress(&u_curr, &outer_block);
+        sha1_compress(&u_curr, &block_b);
 
         var t: Sha1State = u_curr;
 
         // Iterations 2..=iterations.
         for (var iter: u32 = 1u; iter < params.iterations; iter = iter + 1u) {
-            var inner_msg: array<u32, 16>;
-            pack_hash_block(&u_curr, &inner_msg);
+            pack_hash_block(&u_curr, &block_a);
 
             var i_state: Sha1State = ipad_state;
-            sha1_compress(&i_state, &inner_msg);
+            sha1_compress(&i_state, &block_a);
 
-            var o_msg: array<u32, 16>;
-            pack_hash_block(&i_state, &o_msg);
+            pack_hash_block(&i_state, &block_b);
 
             u_curr = opad_state;
-            sha1_compress(&u_curr, &o_msg);
+            sha1_compress(&u_curr, &block_b);
 
             t.h0 = t.h0 ^ u_curr.h0;
             t.h1 = t.h1 ^ u_curr.h1;

--- a/src/gpu/pbkdf2.wgsl
+++ b/src/gpu/pbkdf2.wgsl
@@ -1,0 +1,208 @@
+// PBKDF2-HMAC-SHA1 kernel. One workgroup-thread per candidate password.
+//
+// Host responsibilities:
+//   - Zero-pad each password to 64 bytes, pack as 16 big-endian u32s.
+//     (Passwords > 64 bytes are not supported; HMAC's "hash long key" path
+//     would have to be added separately. WinZip-AES passwords are well under
+//     this in practice.)
+//   - For each output block index i in 1..=n_blocks, build the U_1 message
+//     block (salt || i_be32 || 0x80 || zeros || bit_length_be64) padded to
+//     64 bytes, packed as 16 big-endian u32s. Upload n_blocks of these.
+//
+// Standard PBKDF2 micro-optimization: the SHA-1 state after compressing the
+// 64-byte ipad block (and likewise opad) depends only on the password, so
+// we compute each once at the top and reuse them across all 2 * iterations
+// HMAC compressions. ~2x fewer SHA-1 compressions vs naive HMAC.
+
+struct Params {
+    n_passwords: u32,
+    n_blocks: u32,
+    iterations: u32,
+    _pad: u32,
+}
+
+@group(0) @binding(0) var<storage, read> passwords: array<u32>;
+@group(0) @binding(1) var<storage, read> u1_msg_blocks: array<u32>;
+@group(0) @binding(2) var<storage, read_write> derived_keys: array<u32>;
+@group(0) @binding(3) var<uniform> params: Params;
+
+const SHA1_H0: u32 = 0x67452301u;
+const SHA1_H1: u32 = 0xEFCDAB89u;
+const SHA1_H2: u32 = 0x98BADCFEu;
+const SHA1_H3: u32 = 0x10325476u;
+const SHA1_H4: u32 = 0xC3D2E1F0u;
+
+// (64 ipad/opad bytes + 20 inner-hash bytes) * 8 = 672 bits. Constant for
+// every HMAC inner/outer compression after the first message-block.
+const HMAC_INNER_BIT_LEN: u32 = 672u;
+
+// Naga keeps named struct fields as scalars (SROA), whereas `array<u32, 5>`
+// can end up backed by an addressable allocation when ptr<function, _> is
+// taken; using a struct here makes the SROA reliable.
+struct Sha1State {
+    h0: u32,
+    h1: u32,
+    h2: u32,
+    h3: u32,
+    h4: u32,
+}
+
+fn rotl(x: u32, n: u32) -> u32 {
+    return (x << n) | (x >> (32u - n));
+}
+
+fn sha1_compress(state: ptr<function, Sha1State>, block: ptr<function, array<u32, 16>>) {
+    // Rolling 16-word window: W[i] depends only on W[i-3], W[i-8], W[i-14],
+    // W[i-16], so we keep just 16 slots and index by `i & 15`. Cuts VGPR
+    // footprint vs. an explicit `array<u32, 80>`.
+    var w: array<u32, 16>;
+
+    var a = (*state).h0;
+    var b = (*state).h1;
+    var c = (*state).h2;
+    var d = (*state).h3;
+    var e = (*state).h4;
+
+    for (var i: u32 = 0u; i < 80u; i = i + 1u) {
+        let idx = i & 15u;
+        var word: u32;
+        if (i < 16u) {
+            word = (*block)[i];
+        } else {
+            // The four reads are W[i-3], W[i-8], W[i-14], W[i-16]; the last
+            // collides with `idx` (where we'll write) but is read first.
+            word = rotl(
+                w[(i + 13u) & 15u] ^ w[(i + 8u) & 15u] ^ w[(i + 2u) & 15u] ^ w[idx],
+                1u,
+            );
+        }
+        w[idx] = word;
+
+        var f: u32;
+        var k: u32;
+        if (i < 20u) {
+            f = (b & c) | ((~b) & d);
+            k = 0x5A827999u;
+        } else if (i < 40u) {
+            f = b ^ c ^ d;
+            k = 0x6ED9EBA1u;
+        } else if (i < 60u) {
+            f = (b & c) | (b & d) | (c & d);
+            k = 0x8F1BBCDCu;
+        } else {
+            f = b ^ c ^ d;
+            k = 0xCA62C1D6u;
+        }
+        let t = rotl(a, 5u) + f + e + k + word;
+        e = d;
+        d = c;
+        c = rotl(b, 30u);
+        b = a;
+        a = t;
+    }
+
+    (*state).h0 = (*state).h0 + a;
+    (*state).h1 = (*state).h1 + b;
+    (*state).h2 = (*state).h2 + c;
+    (*state).h3 = (*state).h3 + d;
+    (*state).h4 = (*state).h4 + e;
+}
+
+// Build the standard 64-byte block that wraps a 20-byte inner hash for HMAC's
+// outer compression (or for any subsequent HMAC iteration's inner compression).
+fn pack_hash_block(hash: ptr<function, Sha1State>, block: ptr<function, array<u32, 16>>) {
+    (*block)[0] = (*hash).h0;
+    (*block)[1] = (*hash).h1;
+    (*block)[2] = (*hash).h2;
+    (*block)[3] = (*hash).h3;
+    (*block)[4] = (*hash).h4;
+    (*block)[5] = 0x80000000u;
+    (*block)[6] = 0u;
+    (*block)[7] = 0u;
+    (*block)[8] = 0u;
+    (*block)[9] = 0u;
+    (*block)[10] = 0u;
+    (*block)[11] = 0u;
+    (*block)[12] = 0u;
+    (*block)[13] = 0u;
+    (*block)[14] = 0u;
+    (*block)[15] = HMAC_INNER_BIT_LEN;
+}
+
+@compute @workgroup_size(256)
+fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
+    let pid = gid.x;
+    if (pid >= params.n_passwords) {
+        return;
+    }
+
+    // Two reusable 16-word block buffers. Naming each role separately
+    // (ipad, opad, u1_block, outer_block, inner_msg, o_msg) made naga emit
+    // six distinct `var<function>` allocations, pushing NVIDIA threads past
+    // ~100 registers and capping SM occupancy at ~25%. Live-range analysis
+    // shows only two are ever needed at once: block_a holds password- or
+    // message-derived input, block_b holds hash-derived input.
+    var block_a: array<u32, 16>;
+    var block_b: array<u32, 16>;
+
+    // 1. Build ipad and opad blocks (password XOR 0x36.. / 0x5C..).
+    let pw_off = pid * 16u;
+    for (var w: u32 = 0u; w < 16u; w = w + 1u) {
+        let word = passwords[pw_off + w];
+        block_a[w] = word ^ 0x36363636u;
+        block_b[w] = word ^ 0x5C5C5C5Cu;
+    }
+
+    // 2. Precompute SHA-1 state after one ipad / opad compression.
+    var ipad_state = Sha1State(SHA1_H0, SHA1_H1, SHA1_H2, SHA1_H3, SHA1_H4);
+    sha1_compress(&ipad_state, &block_a);
+
+    var opad_state = Sha1State(SHA1_H0, SHA1_H1, SHA1_H2, SHA1_H3, SHA1_H4);
+    sha1_compress(&opad_state, &block_b);
+
+    // 3. For each output block index in 1..=n_blocks: derive T_i and write out.
+    for (var blk: u32 = 0u; blk < params.n_blocks; blk = blk + 1u) {
+        // U_1: HMAC inner = SHA1(ipad || salt || (blk+1)_be32). The host has
+        // pre-built that 64-byte block (after the ipad prefix already absorbed).
+        let msg_off = blk * 16u;
+        for (var w: u32 = 0u; w < 16u; w = w + 1u) {
+            block_a[w] = u1_msg_blocks[msg_off + w];
+        }
+
+        var inner: Sha1State = ipad_state;
+        sha1_compress(&inner, &block_a);
+
+        pack_hash_block(&inner, &block_b);
+
+        var u_curr: Sha1State = opad_state;
+        sha1_compress(&u_curr, &block_b);
+
+        var t: Sha1State = u_curr;
+
+        // Iterations 2..=iterations.
+        for (var iter: u32 = 1u; iter < params.iterations; iter = iter + 1u) {
+            pack_hash_block(&u_curr, &block_a);
+
+            var i_state: Sha1State = ipad_state;
+            sha1_compress(&i_state, &block_a);
+
+            pack_hash_block(&i_state, &block_b);
+
+            u_curr = opad_state;
+            sha1_compress(&u_curr, &block_b);
+
+            t.h0 = t.h0 ^ u_curr.h0;
+            t.h1 = t.h1 ^ u_curr.h1;
+            t.h2 = t.h2 ^ u_curr.h2;
+            t.h3 = t.h3 ^ u_curr.h3;
+            t.h4 = t.h4 ^ u_curr.h4;
+        }
+
+        let dk_off = pid * (params.n_blocks * 5u) + blk * 5u;
+        derived_keys[dk_off + 0u] = t.h0;
+        derived_keys[dk_off + 1u] = t.h1;
+        derived_keys[dk_off + 2u] = t.h2;
+        derived_keys[dk_off + 3u] = t.h3;
+        derived_keys[dk_off + 4u] = t.h4;
+    }
+}

--- a/src/gpu/sha1.rs
+++ b/src/gpu/sha1.rs
@@ -1,0 +1,217 @@
+// Single-block SHA-1 driver kernel — exists only to validate the WGSL
+// `sha1_compress` against the RustCrypto reference. Production code path is
+// in `pbkdf2.rs`; this file is test-only.
+
+#![cfg(test)]
+
+use std::borrow::Cow;
+
+use crate::gpu::GpuContext;
+
+fn pad_message(message: &[u8]) -> Vec<u32> {
+    let bit_len = (message.len() as u64) * 8;
+    let mut padded = message.to_vec();
+    padded.push(0x80);
+    while padded.len() % 64 != 56 {
+        padded.push(0);
+    }
+    padded.extend_from_slice(&bit_len.to_be_bytes());
+    debug_assert_eq!(padded.len() % 64, 0);
+
+    padded
+        .chunks_exact(4)
+        .map(|c| u32::from_be_bytes([c[0], c[1], c[2], c[3]]))
+        .collect()
+}
+
+fn sha1_gpu(ctx: &GpuContext, message: &[u8]) -> Result<[u8; 20], String> {
+    pollster::block_on(sha1_gpu_async(ctx, message))
+}
+
+async fn sha1_gpu_async(ctx: &GpuContext, message: &[u8]) -> Result<[u8; 20], String> {
+    use wgpu::util::DeviceExt;
+
+    let blocks_words = pad_message(message);
+    let n_blocks = (blocks_words.len() / 16) as u32;
+    let blocks_bytes: &[u8] = bytemuck::cast_slice(&blocks_words);
+
+    let blocks_buffer = ctx
+        .device
+        .create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("sha1-blocks"),
+            contents: blocks_bytes,
+            usage: wgpu::BufferUsages::STORAGE,
+        });
+
+    let state_buffer = ctx.device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("sha1-state"),
+        size: 5 * 4,
+        usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_SRC,
+        mapped_at_creation: false,
+    });
+
+    let params = [n_blocks, 0u32, 0u32, 0u32];
+    let params_buffer = ctx
+        .device
+        .create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("sha1-params"),
+            contents: bytemuck::cast_slice(&params),
+            usage: wgpu::BufferUsages::UNIFORM,
+        });
+
+    let staging = ctx.device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("sha1-staging"),
+        size: 5 * 4,
+        usage: wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::COPY_DST,
+        mapped_at_creation: false,
+    });
+
+    let shader = ctx
+        .device
+        .create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("sha1-shader"),
+            source: wgpu::ShaderSource::Wgsl(Cow::Borrowed(include_str!("sha1.wgsl"))),
+        });
+
+    let pipeline = ctx
+        .device
+        .create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+            label: Some("sha1-pipeline"),
+            layout: None,
+            module: &shader,
+            entry_point: Some("main"),
+            compilation_options: Default::default(),
+            cache: None,
+        });
+
+    let bgl = pipeline.get_bind_group_layout(0);
+    let bind_group = ctx.device.create_bind_group(&wgpu::BindGroupDescriptor {
+        label: Some("sha1-bind-group"),
+        layout: &bgl,
+        entries: &[
+            wgpu::BindGroupEntry {
+                binding: 0,
+                resource: blocks_buffer.as_entire_binding(),
+            },
+            wgpu::BindGroupEntry {
+                binding: 1,
+                resource: state_buffer.as_entire_binding(),
+            },
+            wgpu::BindGroupEntry {
+                binding: 2,
+                resource: params_buffer.as_entire_binding(),
+            },
+        ],
+    });
+
+    let mut encoder = ctx
+        .device
+        .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("sha1-encoder"),
+        });
+    {
+        let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
+            label: Some("sha1-pass"),
+            timestamp_writes: None,
+        });
+        pass.set_pipeline(&pipeline);
+        pass.set_bind_group(0, &bind_group, &[]);
+        pass.dispatch_workgroups(1, 1, 1);
+    }
+    encoder.copy_buffer_to_buffer(&state_buffer, 0, &staging, 0, 5 * 4);
+    ctx.queue.submit(Some(encoder.finish()));
+
+    let slice = staging.slice(..);
+    let (sender, receiver) = std::sync::mpsc::channel();
+    slice.map_async(wgpu::MapMode::Read, move |r| {
+        let _ = sender.send(r);
+    });
+    ctx.device
+        .poll(wgpu::PollType::wait_indefinitely())
+        .expect("poll");
+    receiver
+        .recv()
+        .map_err(|e| format!("map_async channel closed: {e}"))?
+        .map_err(|e| format!("buffer map failed: {e}"))?;
+
+    let mapped = slice.get_mapped_range();
+    let state: &[u32] = bytemuck::cast_slice(&mapped);
+    let mut digest = [0u8; 20];
+    for (i, w) in state.iter().enumerate() {
+        digest[i * 4..i * 4 + 4].copy_from_slice(&w.to_be_bytes());
+    }
+    drop(mapped);
+    staging.unmap();
+
+    Ok(digest)
+}
+
+mod tests {
+    use super::*;
+    use sha1::{Digest, Sha1};
+
+    fn cpu_digest(msg: &[u8]) -> [u8; 20] {
+        let out = Sha1::digest(msg);
+        let mut arr = [0u8; 20];
+        arr.copy_from_slice(&out);
+        arr
+    }
+
+    fn check(msg: &[u8]) {
+        let ctx = GpuContext::init_blocking().expect("GPU init");
+        let gpu = sha1_gpu(&ctx, msg).expect("sha1_gpu");
+        let cpu = cpu_digest(msg);
+        assert_eq!(
+            gpu,
+            cpu,
+            "mismatch for message of length {}: gpu={:02x?} cpu={:02x?}",
+            msg.len(),
+            gpu,
+            cpu
+        );
+    }
+
+    #[test]
+    fn sha1_empty() {
+        check(b"");
+    }
+
+    #[test]
+    fn sha1_abc() {
+        check(b"abc");
+    }
+
+    #[test]
+    fn sha1_two_blocks() {
+        // FIPS 180 multi-block test vector — exactly 56 bytes, padding spills
+        // into a second block.
+        check(b"abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq");
+    }
+
+    #[test]
+    fn sha1_exactly_one_block() {
+        // 55 bytes — last message that still fits with padding in a single block.
+        check(&[b'a'; 55]);
+    }
+
+    #[test]
+    fn sha1_64_bytes() {
+        // Exactly one block of message — padding forces a second block.
+        check(&[b'a'; 64]);
+    }
+
+    #[test]
+    fn sha1_long_random_lengths() {
+        // Sweep awkward sizes around block boundaries.
+        for len in [1, 3, 55, 56, 63, 64, 65, 119, 120, 127, 128, 200, 1000] {
+            let msg: Vec<u8> = (0..len).map(|i| (i as u8).wrapping_mul(31)).collect();
+            let ctx = GpuContext::init_blocking().expect("GPU init");
+            let gpu = sha1_gpu(&ctx, &msg).expect("sha1_gpu");
+            let cpu = cpu_digest(&msg);
+            assert_eq!(
+                gpu, cpu,
+                "mismatch at len {len}: gpu={gpu:02x?} cpu={cpu:02x?}"
+            );
+        }
+    }
+}

--- a/src/gpu/sha1.rs
+++ b/src/gpu/sha1.rs
@@ -158,8 +158,8 @@ mod tests {
     }
 
     fn check(msg: &[u8]) {
-        let ctx = GpuContext::init_blocking().expect("GPU init");
-        let gpu = sha1_gpu(&ctx, msg).expect("sha1_gpu");
+        let ctx = crate::gpu::test_context();
+        let gpu = sha1_gpu(ctx, msg).expect("sha1_gpu");
         let cpu = cpu_digest(msg);
         assert_eq!(
             gpu,
@@ -205,8 +205,8 @@ mod tests {
         // Sweep awkward sizes around block boundaries.
         for len in [1, 3, 55, 56, 63, 64, 65, 119, 120, 127, 128, 200, 1000] {
             let msg: Vec<u8> = (0..len).map(|i| (i as u8).wrapping_mul(31)).collect();
-            let ctx = GpuContext::init_blocking().expect("GPU init");
-            let gpu = sha1_gpu(&ctx, &msg).expect("sha1_gpu");
+            let ctx = crate::gpu::test_context();
+            let gpu = sha1_gpu(ctx, &msg).expect("sha1_gpu");
             let cpu = cpu_digest(&msg);
             assert_eq!(
                 gpu, cpu,

--- a/src/gpu/sha1.rs
+++ b/src/gpu/sha1.rs
@@ -134,7 +134,9 @@ async fn sha1_gpu_async(ctx: &GpuContext, message: &[u8]) -> Result<[u8; 20], St
         .map_err(|e| format!("map_async channel closed: {e}"))?
         .map_err(|e| format!("buffer map failed: {e}"))?;
 
-    let mapped = slice.get_mapped_range();
+    let mapped = slice
+        .get_mapped_range()
+        .map_err(|e| format!("get_mapped_range failed: {e:?}"))?;
     let state: &[u32] = bytemuck::cast_slice(&mapped);
     let mut digest = [0u8; 20];
     for (i, w) in state.iter().enumerate() {

--- a/src/gpu/sha1.wgsl
+++ b/src/gpu/sha1.wgsl
@@ -1,0 +1,102 @@
+// SHA-1 single-thread driver kernel.
+//
+// Input layout (storage buffer `blocks`): N * 16 u32 words. Each u32 is one
+// 4-byte chunk of the (already-padded) SHA-1 message, interpreted big-endian.
+// The host pre-byteswaps via `u32::from_be_bytes`, so the kernel reads each
+// word directly with no per-load swap.
+//
+// Output layout (storage buffer `state`): 5 u32 words = the final 160-bit
+// digest, in the same big-endian-as-native-u32 form (host converts back to
+// bytes via `to_be_bytes`).
+
+@group(0) @binding(0) var<storage, read> blocks: array<u32>;
+@group(0) @binding(1) var<storage, read_write> state_out: array<u32>;
+
+struct Params {
+    n_blocks: u32,
+}
+@group(0) @binding(2) var<uniform> params: Params;
+
+fn rotl(x: u32, n: u32) -> u32 {
+    return (x << n) | (x >> (32u - n));
+}
+
+fn sha1_compress(state: ptr<function, array<u32, 5>>, block_offset: u32) {
+    // Same rolling 16-word window as pbkdf2.wgsl. Perf is irrelevant here
+    // (this kernel runs ≤ a few compressions per call and only exists for
+    // correctness validation), but keeping the two implementations in sync
+    // makes drift bugs impossible.
+    var w: array<u32, 16>;
+
+    var a = (*state)[0];
+    var b = (*state)[1];
+    var c = (*state)[2];
+    var d = (*state)[3];
+    var e = (*state)[4];
+
+    for (var i: u32 = 0u; i < 80u; i = i + 1u) {
+        let idx = i & 15u;
+        var word: u32;
+        if (i < 16u) {
+            word = blocks[block_offset + i];
+        } else {
+            word = rotl(
+                w[(i + 13u) & 15u] ^ w[(i + 8u) & 15u] ^ w[(i + 2u) & 15u] ^ w[idx],
+                1u,
+            );
+        }
+        w[idx] = word;
+
+        var f: u32;
+        var k: u32;
+        if (i < 20u) {
+            f = (b & c) | ((~b) & d);
+            k = 0x5A827999u;
+        } else if (i < 40u) {
+            f = b ^ c ^ d;
+            k = 0x6ED9EBA1u;
+        } else if (i < 60u) {
+            f = (b & c) | (b & d) | (c & d);
+            k = 0x8F1BBCDCu;
+        } else {
+            f = b ^ c ^ d;
+            k = 0xCA62C1D6u;
+        }
+        let t = rotl(a, 5u) + f + e + k + word;
+        e = d;
+        d = c;
+        c = rotl(b, 30u);
+        b = a;
+        a = t;
+    }
+
+    (*state)[0] = (*state)[0] + a;
+    (*state)[1] = (*state)[1] + b;
+    (*state)[2] = (*state)[2] + c;
+    (*state)[3] = (*state)[3] + d;
+    (*state)[4] = (*state)[4] + e;
+}
+
+@compute @workgroup_size(1)
+fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
+    if (gid.x != 0u) {
+        return;
+    }
+
+    var state: array<u32, 5>;
+    state[0] = 0x67452301u;
+    state[1] = 0xEFCDAB89u;
+    state[2] = 0x98BADCFEu;
+    state[3] = 0x10325476u;
+    state[4] = 0xC3D2E1F0u;
+
+    for (var b: u32 = 0u; b < params.n_blocks; b = b + 1u) {
+        sha1_compress(&state, b * 16u);
+    }
+
+    state_out[0] = state[0];
+    state_out[1] = state[1];
+    state_out[2] = state[2];
+    state_out[3] = state[3];
+    state_out[4] = state[4];
+}

--- a/src/gpu/smoke_test.wgsl
+++ b/src/gpu/smoke_test.wgsl
@@ -1,0 +1,10 @@
+@group(0) @binding(0) var<storage, read_write> data: array<u32>;
+
+@compute @workgroup_size(64)
+fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
+    let i = gid.x;
+    if (i >= arrayLength(&data)) {
+        return;
+    }
+    data[i] = data[i] + 1u;
+}

--- a/src/gpu_worker.rs
+++ b/src/gpu_worker.rs
@@ -1,0 +1,144 @@
+use crate::gpu::GpuContext;
+use crate::gpu::pbkdf2::{Pbkdf2Context, SHA1_OUTPUT_BYTES};
+use crate::password_finder::Strategy;
+use crate::password_gen::password_generator_iter;
+use crate::password_mask::mask_password_iter;
+use crate::password_reader::password_dictionary_reader_iter;
+use crate::zip_utils::AesInfo;
+use indicatif::ProgressBar;
+use std::fs::File;
+use std::io::{BufReader, Read};
+use std::path::Path;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::SyncSender;
+use std::thread;
+use std::thread::JoinHandle;
+use zip::ZipArchive;
+use zip::result::ZipError;
+
+const GPU_BATCH: usize = 16_384;
+
+// PBKDF2 iteration count fixed by the WinZip-AES spec (APPNOTE 7.2 § 7.2).
+const WINZIP_AES_PBKDF2_ITERATIONS: u32 = 1000;
+
+fn iterator_for_strategy(
+    strategy: Strategy,
+    progress_bar: ProgressBar,
+) -> Box<dyn Iterator<Item = Vec<u8>> + Send> {
+    match strategy {
+        Strategy::GenPasswords {
+            charset,
+            min_password_len,
+            max_password_len,
+            starting_password,
+        } => Box::new(password_generator_iter(
+            charset,
+            min_password_len,
+            max_password_len,
+            starting_password,
+            progress_bar,
+        )),
+        Strategy::PasswordFile(path) => Box::new(password_dictionary_reader_iter(path)),
+        Strategy::MaskGenPasswords { mask } => Box::new(mask_password_iter(mask)),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn gpu_password_checker(
+    gpu: GpuContext,
+    file_path: &Path,
+    file_number: usize,
+    aes_info: AesInfo,
+    strategy: Strategy,
+    send_password_found: SyncSender<String>,
+    stop_signal: Arc<AtomicBool>,
+    progress_bar: ProgressBar,
+) -> JoinHandle<()> {
+    let file_path = file_path.to_owned();
+    thread::Builder::new()
+        .name("gpu-worker".to_string())
+        .spawn(move || {
+            let n_blocks = aes_info
+                .derived_key_length
+                .div_ceil(SHA1_OUTPUT_BYTES)
+                .max(1) as u32;
+            // GpuContext is supplied by the caller (already validated). The
+            // only way Pbkdf2Context::new fails is via invalid argument
+            // values, which we control here.
+            let pctx = Pbkdf2Context::new(&gpu, GPU_BATCH as u32, n_blocks)
+                .expect("Pbkdf2Context::new with valid arguments");
+
+            let mut iter = iterator_for_strategy(strategy, progress_bar.clone());
+
+            // BufReader is enough — for AES we only re-enter the archive on
+            // verifier hits (1-in-65k), so the whole-file Cursor that the
+            // ZipCrypto CPU path uses isn't needed here.
+            let archive_file = File::open(&file_path).expect("file should exist");
+            let mut archive = ZipArchive::new(BufReader::new(archive_file))
+                .expect("archive validated before-hand");
+            let mut extraction_buffer = Vec::new();
+
+            let mut batch: Vec<Vec<u8>> = Vec::with_capacity(GPU_BATCH);
+            let salt = aes_info.salt;
+            let verifier = aes_info.verification_value;
+            let dk_len = aes_info.derived_key_length;
+
+            loop {
+                if stop_signal.load(Ordering::Relaxed) {
+                    break;
+                }
+
+                batch.clear();
+                for _ in 0..GPU_BATCH {
+                    match iter.next() {
+                        Some(pw) => batch.push(pw),
+                        None => break,
+                    }
+                }
+                if batch.is_empty() {
+                    break;
+                }
+
+                let batch_refs: Vec<&[u8]> = batch.iter().map(Vec::as_slice).collect();
+                let derived =
+                    match pctx.derive(&batch_refs, &salt, WINZIP_AES_PBKDF2_ITERATIONS, dk_len) {
+                        Ok(d) => d,
+                        Err(e) => {
+                            progress_bar.println(format!("GPU PBKDF2 failed: {e}"));
+                            return;
+                        }
+                    };
+
+                for (i, dk) in derived.iter().enumerate() {
+                    if dk[dk_len - 2..] != verifier {
+                        continue;
+                    }
+                    // 1/65536 false-positive rate — verify by full archive read.
+                    let pw_bytes = &batch[i];
+                    match archive.by_index_decrypt(file_number, pw_bytes) {
+                        Err(ZipError::InvalidPassword) => continue,
+                        Err(e) => panic!("Unexpected error {e:?}"),
+                        Ok(zip) if zip.enclosed_name().is_none() => continue,
+                        Ok(mut zip) => {
+                            let zip_size = zip.size() as usize;
+                            extraction_buffer.reserve(zip_size);
+                            if let Ok(data_read) = zip.read_to_end(&mut extraction_buffer)
+                                && data_read == zip_size
+                            {
+                                let password_str = String::from_utf8_lossy(pw_bytes).into_owned();
+                                send_password_found
+                                    .send(password_str)
+                                    .expect("send found password should not fail");
+                                return;
+                            }
+                            extraction_buffer.clear();
+                        }
+                    }
+                }
+
+                progress_bar.inc(batch.len() as u64);
+            }
+        })
+        .unwrap()
+}

--- a/src/gpu_worker.rs
+++ b/src/gpu_worker.rs
@@ -1,0 +1,144 @@
+use crate::gpu::GpuContext;
+use crate::gpu::pbkdf2::{Pbkdf2Context, SHA1_OUTPUT_BYTES};
+use crate::password_finder::Strategy;
+use crate::password_gen::password_generator_iter;
+use crate::password_mask::mask_password_iter;
+use crate::password_reader::password_dictionary_reader_iter;
+use crate::zip_utils::AesInfo;
+use indicatif::ProgressBar;
+use std::fs::File;
+use std::io::{BufReader, Read};
+use std::path::Path;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::SyncSender;
+use std::thread;
+use std::thread::JoinHandle;
+use zip::ZipArchive;
+use zip::result::ZipError;
+
+// PBKDF2 iteration count fixed by the WinZip-AES spec (APPNOTE 7.2 § 7.2).
+const WINZIP_AES_PBKDF2_ITERATIONS: u32 = 1000;
+
+fn iterator_for_strategy(
+    strategy: Strategy,
+    progress_bar: ProgressBar,
+) -> Box<dyn Iterator<Item = Vec<u8>> + Send> {
+    match strategy {
+        Strategy::GenPasswords {
+            charset,
+            min_password_len,
+            max_password_len,
+            starting_password,
+        } => Box::new(password_generator_iter(
+            charset,
+            min_password_len,
+            max_password_len,
+            starting_password,
+            progress_bar,
+        )),
+        Strategy::PasswordFile(path) => Box::new(password_dictionary_reader_iter(path)),
+        Strategy::MaskGenPasswords { mask } => Box::new(mask_password_iter(mask)),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn gpu_password_checker(
+    gpu: GpuContext,
+    file_path: &Path,
+    file_number: usize,
+    aes_info: AesInfo,
+    strategy: Strategy,
+    gpu_batch_size: u32,
+    send_password_found: SyncSender<String>,
+    stop_signal: Arc<AtomicBool>,
+    progress_bar: ProgressBar,
+) -> JoinHandle<()> {
+    let file_path = file_path.to_owned();
+    thread::Builder::new()
+        .name("gpu-worker".to_string())
+        .spawn(move || {
+            let n_blocks = aes_info
+                .derived_key_length
+                .div_ceil(SHA1_OUTPUT_BYTES)
+                .max(1) as u32;
+            // GpuContext is supplied by the caller (already validated). The
+            // only way Pbkdf2Context::new fails is via invalid argument
+            // values, which we control here.
+            let pctx = Pbkdf2Context::new(&gpu, gpu_batch_size, n_blocks)
+                .expect("Pbkdf2Context::new with valid arguments");
+
+            let mut iter = iterator_for_strategy(strategy, progress_bar.clone());
+
+            // BufReader is enough — for AES we only re-enter the archive on
+            // verifier hits (1-in-65k), so the whole-file Cursor that the
+            // ZipCrypto CPU path uses isn't needed here.
+            let archive_file = File::open(&file_path).expect("file should exist");
+            let mut archive = ZipArchive::new(BufReader::new(archive_file))
+                .expect("archive validated before-hand");
+            let mut extraction_buffer = Vec::new();
+
+            let batch_capacity = gpu_batch_size as usize;
+            let mut batch: Vec<Vec<u8>> = Vec::with_capacity(batch_capacity);
+            let salt = aes_info.salt;
+            let verifier = aes_info.verification_value;
+            let dk_len = aes_info.derived_key_length;
+
+            loop {
+                if stop_signal.load(Ordering::Relaxed) {
+                    break;
+                }
+
+                batch.clear();
+                for _ in 0..batch_capacity {
+                    match iter.next() {
+                        Some(pw) => batch.push(pw),
+                        None => break,
+                    }
+                }
+                if batch.is_empty() {
+                    break;
+                }
+
+                let batch_refs: Vec<&[u8]> = batch.iter().map(Vec::as_slice).collect();
+                let derived =
+                    match pctx.derive(&batch_refs, &salt, WINZIP_AES_PBKDF2_ITERATIONS, dk_len) {
+                        Ok(d) => d,
+                        Err(e) => {
+                            progress_bar.println(format!("GPU PBKDF2 failed: {e}"));
+                            return;
+                        }
+                    };
+
+                for (i, dk) in derived.iter().enumerate() {
+                    if dk[dk_len - 2..] != verifier {
+                        continue;
+                    }
+                    // 1/65536 false-positive rate — verify by full archive read.
+                    let pw_bytes = &batch[i];
+                    match archive.by_index_decrypt(file_number, pw_bytes) {
+                        Err(ZipError::InvalidPassword) => continue,
+                        Err(e) => panic!("Unexpected error {e:?}"),
+                        Ok(zip) if zip.enclosed_name().is_none() => continue,
+                        Ok(mut zip) => {
+                            let zip_size = zip.size() as usize;
+                            extraction_buffer.reserve(zip_size);
+                            if let Ok(data_read) = zip.read_to_end(&mut extraction_buffer)
+                                && data_read == zip_size
+                            {
+                                let password_str = String::from_utf8_lossy(pw_bytes).into_owned();
+                                send_password_found
+                                    .send(password_str)
+                                    .expect("send found password should not fail");
+                                return;
+                            }
+                            extraction_buffer.clear();
+                        }
+                    }
+                }
+
+                progress_bar.inc(batch.len() as u64);
+            }
+        })
+        .unwrap()
+}

--- a/src/gpu_worker.rs
+++ b/src/gpu_worker.rs
@@ -17,8 +17,6 @@ use std::thread::JoinHandle;
 use zip::ZipArchive;
 use zip::result::ZipError;
 
-const GPU_BATCH: usize = 16_384;
-
 // PBKDF2 iteration count fixed by the WinZip-AES spec (APPNOTE 7.2 § 7.2).
 const WINZIP_AES_PBKDF2_ITERATIONS: u32 = 1000;
 
@@ -51,6 +49,7 @@ pub fn gpu_password_checker(
     file_number: usize,
     aes_info: AesInfo,
     strategy: Strategy,
+    gpu_batch_size: u32,
     send_password_found: SyncSender<String>,
     stop_signal: Arc<AtomicBool>,
     progress_bar: ProgressBar,
@@ -66,7 +65,7 @@ pub fn gpu_password_checker(
             // GpuContext is supplied by the caller (already validated). The
             // only way Pbkdf2Context::new fails is via invalid argument
             // values, which we control here.
-            let pctx = Pbkdf2Context::new(&gpu, GPU_BATCH as u32, n_blocks)
+            let pctx = Pbkdf2Context::new(&gpu, gpu_batch_size, n_blocks)
                 .expect("Pbkdf2Context::new with valid arguments");
 
             let mut iter = iterator_for_strategy(strategy, progress_bar.clone());
@@ -79,7 +78,8 @@ pub fn gpu_password_checker(
                 .expect("archive validated before-hand");
             let mut extraction_buffer = Vec::new();
 
-            let mut batch: Vec<Vec<u8>> = Vec::with_capacity(GPU_BATCH);
+            let batch_capacity = gpu_batch_size as usize;
+            let mut batch: Vec<Vec<u8>> = Vec::with_capacity(batch_capacity);
             let salt = aes_info.salt;
             let verifier = aes_info.verification_value;
             let dk_len = aes_info.derived_key_length;
@@ -90,7 +90,7 @@ pub fn gpu_password_checker(
                 }
 
                 batch.clear();
-                for _ in 0..GPU_BATCH {
+                for _ in 0..batch_capacity {
                     match iter.next() {
                         Some(pw) => batch.push(pw),
                         None => break,

--- a/src/gpu_worker.rs
+++ b/src/gpu_worker.rs
@@ -1,11 +1,13 @@
 use crate::gpu::GpuContext;
-use crate::gpu::pbkdf2::{Pbkdf2Context, SHA1_OUTPUT_BYTES};
+use crate::gpu::pbkdf2::{HMAC_BLOCK_BYTES, Pbkdf2Context, SHA1_OUTPUT_BYTES};
 use crate::password_finder::Strategy;
 use crate::password_gen::password_generator_iter;
 use crate::password_mask::mask_password_iter;
 use crate::password_reader::password_dictionary_reader_iter;
 use crate::zip_utils::AesInfo;
+use hmac::{Hmac, KeyInit, Mac};
 use indicatif::ProgressBar;
+use sha1::Sha1;
 use std::fs::File;
 use std::io::{BufReader, Read};
 use std::path::Path;
@@ -19,6 +21,47 @@ use zip::result::ZipError;
 
 // PBKDF2 iteration count fixed by the WinZip-AES spec (APPNOTE 7.2 § 7.2).
 const WINZIP_AES_PBKDF2_ITERATIONS: u32 = 1000;
+
+/// Confirm whether `derived_key` (PBKDF2 output for `password`, from GPU or CPU)
+/// is the archive password. First the cheap 2-byte verifier, then — for a
+/// zero-length entry, which the reader cannot authenticate — the WinZip
+/// HMAC-SHA1-80 auth code, otherwise a full decrypt-and-read.
+#[allow(clippy::too_many_arguments)]
+fn key_confirms(
+    derived_key: &[u8],
+    password: &[u8],
+    dk_len: usize,
+    aes_key_length: usize,
+    verifier: &[u8; 2],
+    empty_entry_auth: Option<&[u8; 10]>,
+    archive: &mut ZipArchive<BufReader<File>>,
+    file_number: usize,
+    extraction_buffer: &mut Vec<u8>,
+) -> bool {
+    if derived_key[dk_len - 2..] != *verifier {
+        return false;
+    }
+    if let Some(expected_auth) = empty_entry_auth {
+        // Empty entry: no ciphertext to authenticate, so verify the auth code.
+        let hmac_key = &derived_key[aes_key_length..aes_key_length * 2];
+        let mac =
+            <Hmac<Sha1> as KeyInit>::new_from_slice(hmac_key).expect("HMAC accepts any key length");
+        return mac.finalize().into_bytes()[..10] == *expected_auth;
+    }
+    // 1/65536 verifier false-positive rate — confirm by a full archive read.
+    match archive.by_index_decrypt(file_number, password) {
+        Err(ZipError::InvalidPassword) => false,
+        Err(e) => panic!("Unexpected error {e:?}"),
+        Ok(zip) if zip.enclosed_name().is_none() => false,
+        Ok(mut zip) => {
+            let zip_size = zip.size() as usize;
+            extraction_buffer.reserve(zip_size);
+            let confirmed = matches!(zip.read_to_end(extraction_buffer), Ok(n) if n == zip_size);
+            extraction_buffer.clear();
+            confirmed
+        }
+    }
+}
 
 fn iterator_for_strategy(
     strategy: Strategy,
@@ -83,6 +126,14 @@ pub fn gpu_password_checker(
             let salt = aes_info.salt;
             let verifier = aes_info.verification_value;
             let dk_len = aes_info.derived_key_length;
+            let aes_key_length = aes_info.aes_key_length;
+            let empty_entry_auth = aes_info.empty_entry_auth;
+
+            let send_found = |pw: &[u8]| {
+                send_password_found
+                    .send(String::from_utf8_lossy(pw).into_owned())
+                    .expect("send found password should not fail");
+            };
 
             loop {
                 if stop_signal.load(Ordering::Relaxed) {
@@ -100,40 +151,61 @@ pub fn gpu_password_checker(
                     break;
                 }
 
-                let batch_refs: Vec<&[u8]> = batch.iter().map(Vec::as_slice).collect();
+                // The GPU kernel only handles passwords up to one HMAC block.
+                // Longer ones are rare (WinZip passwords are short) but must not
+                // abort the run — derive their keys on the CPU instead.
+                let gpu_batch: Vec<&[u8]> = batch
+                    .iter()
+                    .map(Vec::as_slice)
+                    .filter(|pw| pw.len() <= HMAC_BLOCK_BYTES)
+                    .collect();
                 let derived =
-                    match pctx.derive(&batch_refs, &salt, WINZIP_AES_PBKDF2_ITERATIONS, dk_len) {
+                    match pctx.derive(&gpu_batch, &salt, WINZIP_AES_PBKDF2_ITERATIONS, dk_len) {
                         Ok(d) => d,
                         Err(e) => {
                             progress_bar.println(format!("GPU PBKDF2 failed: {e}"));
                             return;
                         }
                     };
-
-                for (i, dk) in derived.iter().enumerate() {
-                    if dk[dk_len - 2..] != verifier {
-                        continue;
+                for (dk, pw) in derived.iter().zip(gpu_batch.iter()) {
+                    if key_confirms(
+                        dk,
+                        pw,
+                        dk_len,
+                        aes_key_length,
+                        &verifier,
+                        empty_entry_auth.as_ref(),
+                        &mut archive,
+                        file_number,
+                        &mut extraction_buffer,
+                    ) {
+                        send_found(pw);
+                        return;
                     }
-                    // 1/65536 false-positive rate — verify by full archive read.
-                    let pw_bytes = &batch[i];
-                    match archive.by_index_decrypt(file_number, pw_bytes) {
-                        Err(ZipError::InvalidPassword) => continue,
-                        Err(e) => panic!("Unexpected error {e:?}"),
-                        Ok(zip) if zip.enclosed_name().is_none() => continue,
-                        Ok(mut zip) => {
-                            let zip_size = zip.size() as usize;
-                            extraction_buffer.reserve(zip_size);
-                            if let Ok(data_read) = zip.read_to_end(&mut extraction_buffer)
-                                && data_read == zip_size
-                            {
-                                let password_str = String::from_utf8_lossy(pw_bytes).into_owned();
-                                send_password_found
-                                    .send(password_str)
-                                    .expect("send found password should not fail");
-                                return;
-                            }
-                            extraction_buffer.clear();
-                        }
+                }
+
+                for pw in batch.iter().filter(|pw| pw.len() > HMAC_BLOCK_BYTES) {
+                    let mut cpu_dk = vec![0u8; dk_len];
+                    pbkdf2::pbkdf2::<Hmac<Sha1>>(
+                        pw,
+                        &salt,
+                        WINZIP_AES_PBKDF2_ITERATIONS,
+                        &mut cpu_dk,
+                    )
+                    .expect("PBKDF2 should not fail");
+                    if key_confirms(
+                        &cpu_dk,
+                        pw,
+                        dk_len,
+                        aes_key_length,
+                        &verifier,
+                        empty_entry_auth.as_ref(),
+                        &mut archive,
+                        file_number,
+                        &mut extraction_buffer,
+                    ) {
+                        send_found(pw);
+                        return;
                     }
                 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 // lib to expose functions to criterion benchmarks
 pub mod charsets;
 pub mod finder_errors;
+pub mod gpu;
 pub mod password_gen;
 pub mod password_mask;
 pub mod password_reader;

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,6 +48,7 @@ fn main_result() -> Result<(), FinderError> {
         custom_charsets,
         use_gpu,
         gpu_smoke_test,
+        gpu_batch_size,
     } = get_args()?;
 
     // --gpu-smoke-test exits before any of the search-related logic.
@@ -91,6 +92,7 @@ fn main_result() -> Result<(), FinderError> {
         file_number,
         &strategy,
         use_gpu,
+        gpu_batch_size,
         stop_signal,
     )?;
     // Round to milliseconds — humantime would otherwise drag along ns precision

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,8 @@
 mod args;
 mod charsets;
 mod finder_errors;
+mod gpu;
+mod gpu_worker;
 mod password_finder;
 mod password_gen;
 mod password_mask;
@@ -18,6 +20,7 @@ use crate::password_mask::parse_mask;
 use std::path::Path;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
 
 fn main() {
     let result = main_result();
@@ -43,7 +46,16 @@ fn main_result() -> Result<(), FinderError> {
         starting_password,
         mask,
         custom_charsets,
+        use_gpu,
+        gpu_smoke_test,
     } = get_args()?;
+
+    // --gpu-smoke-test exits before any of the search-related logic.
+    if gpu_smoke_test {
+        std::process::exit(gpu::run_smoke_test_cli());
+    }
+
+    let input_file = input_file.expect("clap requires --inputFile when --gpu-smoke-test is absent");
 
     let strategy = if let Some(dict_path) = password_dictionary {
         let path = Path::new(&dict_path);
@@ -73,9 +85,17 @@ fn main_result() -> Result<(), FinderError> {
     ctrlc::set_handler(move || stop_signal_interrupt.store(true, Ordering::Relaxed))
         .expect("Error setting Ctrl-C handler");
 
-    let password = password_finder(&input_file, workers, file_number, &strategy, stop_signal)?;
-    let elapsed = start_time.elapsed();
-    // display pretty time
+    let password = password_finder(
+        &input_file,
+        workers,
+        file_number,
+        &strategy,
+        use_gpu,
+        stop_signal,
+    )?;
+    // Round to milliseconds — humantime would otherwise drag along ns precision
+    // ("3s 445ms 537us 500ns") which adds noise without information.
+    let elapsed = Duration::from_millis(start_time.elapsed().as_millis() as u64);
     let elapsed = humantime::format_duration(elapsed);
     println!("Time elapsed: {elapsed}");
     match password {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,8 @@
 mod args;
 mod charsets;
 mod finder_errors;
+mod gpu;
+mod gpu_worker;
 mod password_finder;
 mod password_gen;
 mod password_mask;
@@ -42,12 +44,19 @@ fn is_sevenz_archive(path: &str) -> bool {
 fn reject_inapplicable_options(
     is_sevenz: bool,
     file_number_explicit: bool,
+    use_gpu: bool,
 ) -> Result<(), FinderError> {
     if is_sevenz && file_number_explicit {
         return Err(FinderError::CliArgumentError {
             message:
                 "'--file-number' does not apply to 7z archives (every entry shares the password)"
                     .to_string(),
+        });
+    }
+    if is_sevenz && use_gpu {
+        return Err(FinderError::CliArgumentError {
+            message: "'--gpu' is not supported for 7z archives (GPU acceleration is ZIP-AES only)"
+                .to_string(),
         });
     }
     Ok(())
@@ -84,12 +93,23 @@ fn main_result() -> Result<bool, FinderError> {
         custom_charsets,
         quiet,
         json,
+        use_gpu,
+        gpu_smoke_test,
+        gpu_batch_size,
     } = get_args()?;
+
+    // --gpu-smoke-test exits before any of the search-related logic.
+    if gpu_smoke_test {
+        std::process::exit(gpu::run_smoke_test_cli());
+    }
+
+    let input_file =
+        input_file.expect("clap requires an input file unless --gpu-smoke-test is present");
 
     // Reject options that do not apply to the detected archive type before doing
     // any work, rather than silently ignoring them.
     let is_sevenz = is_sevenz_archive(&input_file);
-    reject_inapplicable_options(is_sevenz, file_number_explicit)?;
+    reject_inapplicable_options(is_sevenz, file_number_explicit, use_gpu)?;
 
     let strategy = if let Some(dict_path) = password_dictionary {
         let path = Path::new(&dict_path);
@@ -128,6 +148,8 @@ fn main_result() -> Result<bool, FinderError> {
             file_number,
             &strategy,
             quiet,
+            use_gpu,
+            gpu_batch_size,
             stop_signal,
         )?
     };
@@ -187,14 +209,15 @@ mod tests {
     use super::*;
 
     #[test]
-    fn file_number_rejected_only_for_sevenz_when_explicit() {
-        // 7z + explicit --file-number -> rejected
-        assert!(reject_inapplicable_options(true, true).is_err());
-        // 7z without an explicit --file-number (default) -> accepted
-        assert!(reject_inapplicable_options(true, false).is_ok());
-        // zip always accepts --file-number
-        assert!(reject_inapplicable_options(false, true).is_ok());
-        assert!(reject_inapplicable_options(false, false).is_ok());
+    fn options_rejected_only_for_sevenz() {
+        // 7z + explicit --file-number -> rejected; 7z + --gpu -> rejected
+        assert!(reject_inapplicable_options(true, true, false).is_err());
+        assert!(reject_inapplicable_options(true, false, true).is_err());
+        // 7z with neither -> accepted
+        assert!(reject_inapplicable_options(true, false, false).is_ok());
+        // zip accepts both
+        assert!(reject_inapplicable_options(false, true, true).is_ok());
+        assert!(reject_inapplicable_options(false, false, false).is_ok());
     }
 
     #[test]

--- a/src/password_finder.rs
+++ b/src/password_finder.rs
@@ -35,6 +35,7 @@ pub fn password_finder(
     file_number: usize,
     strategy: &Strategy,
     use_gpu: bool,
+    gpu_batch_size: u32,
     stop_signal: Arc<AtomicBool>,
 ) -> Result<Option<String>, FinderError> {
     let file_path = Path::new(zip_path);
@@ -115,13 +116,13 @@ pub fn password_finder(
     // amortization point. GPU has ~100ms of fixed dispatch latency per batch,
     // and that floor exceeds any plausible CPU run-time on small workloads —
     // see the bench: AES-128 crossover ≈ 20k passwords, AES-256 ≈ 8.5k.
-    // We use one GPU batch (16 384) as a conservative threshold that holds
-    // for both AES variants.
-    const GPU_MIN_REMAINING: usize = 16_384;
+    // Threshold tracks the user's batch size: a half-empty dispatch wastes the
+    // same per-batch cost regardless of how full it is.
+    let gpu_min_remaining = gpu_batch_size as usize;
     let remaining = total_password_count.saturating_sub(skipped);
-    let use_gpu = if use_gpu && remaining < GPU_MIN_REMAINING {
+    let use_gpu = if use_gpu && remaining < gpu_min_remaining {
         progress_bar.println(format!(
-            "Search space too small for GPU ({remaining} candidates < {GPU_MIN_REMAINING}); using CPU"
+            "Search space too small for GPU ({remaining} candidates < {gpu_min_remaining}); using CPU"
         ));
         false
     } else {
@@ -140,7 +141,7 @@ pub fn password_finder(
         // user with "Password not found" + exit 0.
         let gpu = GpuContext::init_blocking().map_err(|e| FinderError::Gpu { message: e })?;
         progress_bar.println(format!(
-            "Starting GPU worker on {} ({}, {})",
+            "Starting GPU worker on {} ({}, {}) — batch size {gpu_batch_size}",
             gpu.adapter_name, gpu.backend, gpu.device_type
         ));
         worker_handles.push(gpu_password_checker(
@@ -149,6 +150,7 @@ pub fn password_finder(
             file_number,
             aes_info,
             strategy.clone(),
+            gpu_batch_size,
             send_found_password.clone(),
             stop_signal.clone(),
             progress_bar.clone(),
@@ -220,6 +222,7 @@ mod tests {
             file_number,
             &strategy,
             false,
+            16_384,
             Arc::new(AtomicBool::new(false)),
         )
     }
@@ -236,6 +239,7 @@ mod tests {
             file_number,
             &strategy,
             false,
+            16_384,
             Arc::new(AtomicBool::new(false)),
         )
     }
@@ -336,6 +340,7 @@ mod tests {
             file_number,
             &strategy,
             false,
+            16_384,
             Arc::new(AtomicBool::new(false)),
         )
     }

--- a/src/password_finder.rs
+++ b/src/password_finder.rs
@@ -29,13 +29,24 @@ pub enum Strategy {
     },
 }
 
+// Picked from `wgpu::DeviceType` via the stringified value stored on
+// `GpuContext`. Discrete cards have far more SMs/CUs to fill than an iGPU,
+// so they need a bigger dispatch to saturate; integrated/virtual/CPU
+// adapters stay on the conservative iGPU-tuned default.
+fn default_batch_size_for(device_type: &str) -> u32 {
+    match device_type {
+        "DiscreteGpu" => 65_536,
+        _ => 16_384,
+    }
+}
+
 pub fn password_finder(
     zip_path: &str,
     workers: usize,
     file_number: usize,
     strategy: &Strategy,
     use_gpu: bool,
-    gpu_batch_size: u32,
+    gpu_batch_size: Option<u32>,
     stop_signal: Arc<AtomicBool>,
 ) -> Result<Option<String>, FinderError> {
     let file_path = Path::new(zip_path);
@@ -112,36 +123,47 @@ pub fn password_finder(
     // reset progress_bar speed
     progress_bar.reset_elapsed();
 
-    // Auto-fall back to CPU when the remaining search space is below the GPU
-    // amortization point. GPU has ~100ms of fixed dispatch latency per batch,
-    // and that floor exceeds any plausible CPU run-time on small workloads —
-    // see the bench: AES-128 crossover ≈ 20k passwords, AES-256 ≈ 8.5k.
-    // Threshold tracks the user's batch size: a half-empty dispatch wastes the
-    // same per-batch cost regardless of how full it is.
-    let gpu_min_remaining = gpu_batch_size as usize;
-    let remaining = total_password_count.saturating_sub(skipped);
-    let use_gpu = if use_gpu && remaining < gpu_min_remaining {
-        progress_bar.println(format!(
-            "Search space too small for GPU ({remaining} candidates < {gpu_min_remaining}); using CPU"
-        ));
-        false
-    } else {
-        use_gpu
-    };
-
     let mut worker_handles = Vec::new();
+    let remaining = total_password_count.saturating_sub(skipped);
 
-    if use_gpu {
-        let aes_info = aes_info.ok_or(CliArgumentError {
+    // GPU init happens here (eagerly, on the main thread) for two reasons:
+    // (1) failures surface as a clean error instead of a silently-exiting
+    // worker that would leave the user with "Password not found" + exit 0;
+    // (2) when the batch size is auto-selected, it depends on the adapter's
+    // device_type, so we can't compute the CPU-fallback threshold until we've
+    // inspected the adapter.
+    let gpu_setup = if use_gpu {
+        let aes_info = aes_info.clone().ok_or(CliArgumentError {
             message: "--gpu requires an AES-encrypted archive (ZipCrypto is not supported on GPU)"
                 .to_string(),
         })?;
-        // Init the GPU eagerly on the main thread so init failures surface as
-        // a clean error instead of a silently-exiting worker that leaves the
-        // user with "Password not found" + exit 0.
         let gpu = GpuContext::init_blocking().map_err(|e| FinderError::Gpu { message: e })?;
+        let (resolved_batch, batch_origin) = match gpu_batch_size {
+            Some(v) => (v, "user".to_string()),
+            None => (
+                default_batch_size_for(&gpu.device_type),
+                format!("auto, {}", gpu.device_type),
+            ),
+        };
+        // Auto-fall back to CPU when the remaining search space is below one
+        // batch — a half-empty dispatch wastes the same fixed per-batch cost
+        // (~100 ms wgpu/driver overhead) as a full one, and that floor exceeds
+        // any plausible CPU run-time on small workloads.
+        if remaining < resolved_batch as usize {
+            progress_bar.println(format!(
+                "Search space too small for GPU ({remaining} candidates < {resolved_batch}); using CPU"
+            ));
+            None
+        } else {
+            Some((gpu, aes_info, resolved_batch, batch_origin))
+        }
+    } else {
+        None
+    };
+
+    if let Some((gpu, aes_info, resolved_batch, batch_origin)) = gpu_setup {
         progress_bar.println(format!(
-            "Starting GPU worker on {} ({}, {}) — batch size {gpu_batch_size}",
+            "Starting GPU worker on {} ({}, {}) — batch size {resolved_batch} ({batch_origin})",
             gpu.adapter_name, gpu.backend, gpu.device_type
         ));
         worker_handles.push(gpu_password_checker(
@@ -150,7 +172,7 @@ pub fn password_finder(
             file_number,
             aes_info,
             strategy.clone(),
-            gpu_batch_size,
+            resolved_batch,
             send_found_password.clone(),
             stop_signal.clone(),
             progress_bar.clone(),
@@ -197,6 +219,20 @@ mod tests {
     use crate::charsets;
     use crate::password_mask::parse_mask;
 
+    // Pins the heuristic mapping and documents the `wgpu::DeviceType` Debug
+    // strings we rely on. The unknown-string case explicitly captures the
+    // fall-through behavior: if wgpu ever renames a variant, we degrade to
+    // the conservative iGPU default rather than crashing.
+    #[test]
+    fn default_batch_size_picks_for_device_type() {
+        assert_eq!(default_batch_size_for("DiscreteGpu"), 65_536);
+        assert_eq!(default_batch_size_for("IntegratedGpu"), 16_384);
+        assert_eq!(default_batch_size_for("VirtualGpu"), 16_384);
+        assert_eq!(default_batch_size_for("Cpu"), 16_384);
+        assert_eq!(default_batch_size_for("Other"), 16_384);
+        assert_eq!(default_batch_size_for("FuturewgpuVariant"), 16_384);
+    }
+
     fn find_password_gen(
         path: &str,
         max_password_len: usize,
@@ -222,7 +258,7 @@ mod tests {
             file_number,
             &strategy,
             false,
-            16_384,
+            None,
             Arc::new(AtomicBool::new(false)),
         )
     }
@@ -239,7 +275,7 @@ mod tests {
             file_number,
             &strategy,
             false,
-            16_384,
+            None,
             Arc::new(AtomicBool::new(false)),
         )
     }
@@ -340,7 +376,7 @@ mod tests {
             file_number,
             &strategy,
             false,
-            16_384,
+            None,
             Arc::new(AtomicBool::new(false)),
         )
     }

--- a/src/password_finder.rs
+++ b/src/password_finder.rs
@@ -1,4 +1,7 @@
 use crate::finder_errors::FinderError;
+use crate::finder_errors::FinderError::CliArgumentError;
+use crate::gpu::GpuContext;
+use crate::gpu_worker::gpu_password_checker;
 use crate::password_gen::password_generator_count;
 use crate::password_mask::{ParsedMask, mask_password_count};
 use crate::password_reader::password_reader_count;
@@ -31,6 +34,7 @@ pub fn password_finder(
     workers: usize,
     file_number: usize,
     strategy: &Strategy,
+    use_gpu: bool,
     stop_signal: Arc<AtomicBool>,
 ) -> Result<Option<String>, FinderError> {
     let file_path = Path::new(zip_path);
@@ -107,22 +111,63 @@ pub fn password_finder(
     // reset progress_bar speed
     progress_bar.reset_elapsed();
 
-    let mut worker_handles = Vec::with_capacity(workers);
+    // Auto-fall back to CPU when the remaining search space is below the GPU
+    // amortization point. GPU has ~100ms of fixed dispatch latency per batch,
+    // and that floor exceeds any plausible CPU run-time on small workloads —
+    // see the bench: AES-128 crossover ≈ 20k passwords, AES-256 ≈ 8.5k.
+    // We use one GPU batch (16 384) as a conservative threshold that holds
+    // for both AES variants.
+    const GPU_MIN_REMAINING: usize = 16_384;
+    let remaining = total_password_count.saturating_sub(skipped);
+    let use_gpu = if use_gpu && remaining < GPU_MIN_REMAINING {
+        progress_bar.println(format!(
+            "Search space too small for GPU ({remaining} candidates < {GPU_MIN_REMAINING}); using CPU"
+        ));
+        false
+    } else {
+        use_gpu
+    };
 
-    progress_bar.println(format!("Starting {workers} workers to test passwords"));
-    for i in 1..=workers {
-        let join_handle = password_checker(
-            i,
-            workers,
+    let mut worker_handles = Vec::new();
+
+    if use_gpu {
+        let aes_info = aes_info.ok_or(CliArgumentError {
+            message: "--gpu requires an AES-encrypted archive (ZipCrypto is not supported on GPU)"
+                .to_string(),
+        })?;
+        // Init the GPU eagerly on the main thread so init failures surface as
+        // a clean error instead of a silently-exiting worker that leaves the
+        // user with "Password not found" + exit 0.
+        let gpu = GpuContext::init_blocking().map_err(|e| FinderError::Gpu { message: e })?;
+        progress_bar.println(format!(
+            "Starting GPU worker on {} ({}, {})",
+            gpu.adapter_name, gpu.backend, gpu.device_type
+        ));
+        worker_handles.push(gpu_password_checker(
+            gpu,
             file_path,
             file_number,
-            aes_info.clone(),
+            aes_info,
             strategy.clone(),
             send_found_password.clone(),
             stop_signal.clone(),
             progress_bar.clone(),
-        );
-        worker_handles.push(join_handle);
+        ));
+    } else {
+        progress_bar.println(format!("Starting {workers} workers to test passwords"));
+        for i in 1..=workers {
+            worker_handles.push(password_checker(
+                i,
+                workers,
+                file_path,
+                file_number,
+                aes_info.clone(),
+                strategy.clone(),
+                send_found_password.clone(),
+                stop_signal.clone(),
+                progress_bar.clone(),
+            ));
+        }
     }
 
     // drop reference in `main` so that it disappears completely with workers for a clean shutdown
@@ -174,6 +219,7 @@ mod tests {
             workers,
             file_number,
             &strategy,
+            false,
             Arc::new(AtomicBool::new(false)),
         )
     }
@@ -189,6 +235,7 @@ mod tests {
             workers,
             file_number,
             &strategy,
+            false,
             Arc::new(AtomicBool::new(false)),
         )
     }
@@ -288,6 +335,7 @@ mod tests {
             workers,
             file_number,
             &strategy,
+            false,
             Arc::new(AtomicBool::new(false)),
         )
     }

--- a/src/password_finder.rs
+++ b/src/password_finder.rs
@@ -1,4 +1,7 @@
 use crate::finder_errors::FinderError;
+use crate::finder_errors::FinderError::CliArgumentError;
+use crate::gpu::GpuContext;
+use crate::gpu_worker::gpu_password_checker;
 use crate::password_gen::password_generator_count;
 use crate::password_mask::{ParsedMask, mask_password_count};
 use crate::password_reader::password_reader_count;
@@ -26,12 +29,26 @@ pub enum Strategy {
     },
 }
 
+// Picked from `wgpu::DeviceType` via the stringified value stored on
+// `GpuContext`. Discrete cards have far more SMs/CUs to fill than an iGPU,
+// so they need a bigger dispatch to saturate; integrated/virtual/CPU
+// adapters stay on the conservative iGPU-tuned default.
+fn default_batch_size_for(device_type: &str) -> u32 {
+    match device_type {
+        "DiscreteGpu" => 65_536,
+        _ => 16_384,
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
 pub fn password_finder(
     zip_path: &str,
     workers: usize,
     file_number: usize,
     strategy: &Strategy,
     quiet: bool,
+    use_gpu: bool,
+    gpu_batch_size: Option<u32>,
     stop_signal: Arc<AtomicBool>,
 ) -> Result<Option<String>, FinderError> {
     let file_path = Path::new(zip_path);
@@ -113,22 +130,75 @@ pub fn password_finder(
     // reset progress_bar speed
     progress_bar.reset_elapsed();
 
-    let mut worker_handles = Vec::with_capacity(workers);
+    let mut worker_handles = Vec::new();
+    let remaining = total_password_count.saturating_sub(skipped);
 
-    progress_bar.println(format!("Starting {workers} workers to test passwords"));
-    for i in 1..=workers {
-        let join_handle = password_checker(
-            i,
-            workers,
+    // GPU init happens here (eagerly, on the main thread) for two reasons:
+    // (1) failures surface as a clean error instead of a silently-exiting
+    // worker that would leave the user with "Password not found" + exit 0;
+    // (2) when the batch size is auto-selected, it depends on the adapter's
+    // device_type, so we can't compute the CPU-fallback threshold until we've
+    // inspected the adapter.
+    let gpu_setup = if use_gpu {
+        let aes_info = aes_info.clone().ok_or(CliArgumentError {
+            message: "--gpu requires an AES-encrypted archive (ZipCrypto is not supported on GPU)"
+                .to_string(),
+        })?;
+        let gpu = GpuContext::init_blocking().map_err(|e| FinderError::Gpu { message: e })?;
+        let (resolved_batch, batch_origin) = match gpu_batch_size {
+            Some(v) => (v, "user".to_string()),
+            None => (
+                default_batch_size_for(&gpu.device_type),
+                format!("auto, {}", gpu.device_type),
+            ),
+        };
+        // Auto-fall back to CPU when the remaining search space is below one
+        // batch — a half-empty dispatch wastes the same fixed per-batch cost
+        // (~100 ms wgpu/driver overhead) as a full one, and that floor exceeds
+        // any plausible CPU run-time on small workloads.
+        if remaining < resolved_batch as usize {
+            progress_bar.println(format!(
+                "Search space too small for GPU ({remaining} candidates < {resolved_batch}); using CPU"
+            ));
+            None
+        } else {
+            Some((gpu, aes_info, resolved_batch, batch_origin))
+        }
+    } else {
+        None
+    };
+
+    if let Some((gpu, aes_info, resolved_batch, batch_origin)) = gpu_setup {
+        progress_bar.println(format!(
+            "Starting GPU worker on {} ({}, {}) — batch size {resolved_batch} ({batch_origin})",
+            gpu.adapter_name, gpu.backend, gpu.device_type
+        ));
+        worker_handles.push(gpu_password_checker(
+            gpu,
             file_path,
             file_number,
-            aes_info.clone(),
+            aes_info,
             strategy.clone(),
+            resolved_batch,
             send_found_password.clone(),
             stop_signal.clone(),
             progress_bar.clone(),
-        );
-        worker_handles.push(join_handle);
+        ));
+    } else {
+        progress_bar.println(format!("Starting {workers} workers to test passwords"));
+        for i in 1..=workers {
+            worker_handles.push(password_checker(
+                i,
+                workers,
+                file_path,
+                file_number,
+                aes_info.clone(),
+                strategy.clone(),
+                send_found_password.clone(),
+                stop_signal.clone(),
+                progress_bar.clone(),
+            ));
+        }
     }
 
     // drop reference in `main` so that it disappears completely with workers for a clean shutdown
@@ -156,6 +226,20 @@ mod tests {
     use crate::charsets;
     use crate::password_mask::parse_mask;
 
+    // Pins the heuristic mapping and documents the `wgpu::DeviceType` Debug
+    // strings we rely on. The unknown-string case explicitly captures the
+    // fall-through behavior: if wgpu ever renames a variant, we degrade to
+    // the conservative iGPU default rather than crashing.
+    #[test]
+    fn default_batch_size_picks_for_device_type() {
+        assert_eq!(default_batch_size_for("DiscreteGpu"), 65_536);
+        assert_eq!(default_batch_size_for("IntegratedGpu"), 16_384);
+        assert_eq!(default_batch_size_for("VirtualGpu"), 16_384);
+        assert_eq!(default_batch_size_for("Cpu"), 16_384);
+        assert_eq!(default_batch_size_for("Other"), 16_384);
+        assert_eq!(default_batch_size_for("FuturewgpuVariant"), 16_384);
+    }
+
     fn find_password_gen(
         path: &str,
         max_password_len: usize,
@@ -181,6 +265,8 @@ mod tests {
             file_number,
             &strategy,
             true,
+            false,
+            None,
             Arc::new(AtomicBool::new(false)),
         )
     }
@@ -197,6 +283,8 @@ mod tests {
             file_number,
             &strategy,
             true,
+            false,
+            None,
             Arc::new(AtomicBool::new(false)),
         )
     }
@@ -255,6 +343,8 @@ mod tests {
             0,
             &strategy,
             true,
+            false,
+            None,
             Arc::new(AtomicBool::new(false)),
         )
         .unwrap();
@@ -318,6 +408,8 @@ mod tests {
             file_number,
             &strategy,
             true,
+            false,
+            None,
             Arc::new(AtomicBool::new(false)),
         )
     }


### PR DESCRIPTION
## Summary

Adds optional **GPU acceleration** for cracking AES-encrypted ZIP archives. The new `--gpu` flag offloads PBKDF2-HMAC-SHA1 key derivation — the dominant cost for WinZip-AES — to the GPU via [`wgpu`](https://github.com/gfx-rs/wgpu), so it runs on any modern desktop GPU through the platform's native API (Vulkan on Linux, Metal on macOS, DX12 on Windows). The GPU backend is compiled into the binary; there are no extra runtime dependencies.

```bash
zip-password-finder -i archive.zip --gpu -p wordlist.txt
```

## What's included

- **`src/gpu/`** — a self-contained GPU module:
  - `GpuContext`: adapter/device initialization (picks the highest-performance adapter).
  - PBKDF2 and SHA-1 compute kernels in WGSL (`pbkdf2.wgsl`, `sha1.wgsl`) with Rust-side input packing and readback (`pbkdf2.rs`, `sha1.rs`).
  - A `Pbkdf2Context` that pre-allocates buffers and compiles the pipeline once, so per-batch cost is one buffer write + one dispatch + one readback.
- **`gpu_worker.rs`** — batches candidates from the existing password iterators (brute-force, dictionary, and mask attacks all supported), derives keys on-GPU, checks the 2-byte WinZip-AES password verifier, and confirms any hit with a full archive decrypt (guards against the 1/65536 verifier false-positive rate).
- **`password_finder` wiring** — GPU init happens eagerly on the main thread so failures surface as a clean error instead of a silently-exiting worker. Batch size is auto-selected from the adapter's device type, and the run **falls back to the CPU path automatically** when the remaining search space is smaller than a single batch (a half-empty dispatch pays the same fixed overhead).
- **CLI** — `--gpu`, `--gpu-smoke-test` (an `[OK]`/`[FAIL]` capability probe with actionable guidance), and `--gpu-batch-size` to override the auto-selected batch.
- **Benches & CI** — `pbkdf2` and `pbkdf2_gpu` benchmarks; CI installs `mesa-vulkan-drivers` so the GPU tests run under llvmpipe on Linux runners (macOS/Windows use Metal/WARP).

## Correctness & testing

- GPU PBKDF2 output is compared **byte-for-byte against the RustCrypto `pbkdf2` reference** across AES-128/192/256 derived-key lengths, empty and 64-byte passwords, iteration counts, salt lengths 1 through 51, and batch sizes that cross workgroup boundaries (1, 2, 7, 63–65, 257, …).
- The SHA-1 kernel has its own unit tests; the batch-size heuristic is pinned by a test that includes the unknown-`DeviceType` fall-through.

## Scope & limitations

- **AES (WinZip-AES) only.** ZipCrypto is rejected up front with a clear error — the GPU path only accelerates PBKDF2.
- Passwords ≤ 64 bytes and salt ≤ 51 bytes (the HMAC long-key path isn't implemented; WinZip-AES salts are 8/12/16 bytes, so this is a non-issue in practice).
- A single GPU worker runs the search; **CPU cores are idle during a GPU run** (no hybrid CPU+GPU splitting yet).
- Dispatch and readback are synchronous per batch (no overlap of the next dispatch with the current readback).

## Performance

On a Radeon 890M iGPU (RDNA 3.5) the GPU path runs roughly **2–7× faster than 12 CPU cores** for AES brute force — the larger the search space, the bigger the win. Discrete GPUs should do considerably better. Run `cargo bench --bench pbkdf2_gpu` for throughput across batch sizes.

## Incidental changes

- Default `--max-password-len` lowered from 10 to 6, with `--help` now documenting the exponential search-space cost.
- CLI long flags moved to kebab-case (`--input-file`, `--max-password-len`, …), with the old camelCase forms kept as hidden aliases for backwards compatibility. The rename itself landed separately on `master`; this branch is rebased on top of it, so this PR's diff contains only the GPU work.
